### PR TITLE
LP remove scripts

### DIFF
--- a/scripts/DREMTubes_HTCondor.sub
+++ b/scripts/DREMTubes_HTCondor.sub
@@ -1,9 +1,0 @@
-universe = vanilla 
-output = output/job.$(ClusterId).$(ProcId).output 
-error = error/job.$(ClusterId).$(ProcId).error 
-log =  log/job.$(ClusterId).$(ProcId).log 
-RequestCpus = 10
-stream_output = True 
-stream_error = True 
-+JobFlavour = "testmatch" 
-queue

--- a/scripts/DREMTubes_HTCondor_10.7.p01.sh
+++ b/scripts/DREMTubes_HTCondor_10.7.p01.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-source /cvmfs/sft.cern.ch/lcg/contrib/gcc/8.3.0/x86_64-centos7/setup.sh 
-source /cvmfs/geant4.cern.ch/geant4/10.7.p01/x86_64-centos7-gcc8-optdeb-MT/CMake-setup.sh 

--- a/scripts/DREMTubes_lxplus_10.7.p01.sh
+++ b/scripts/DREMTubes_lxplus_10.7.p01.sh
@@ -1,6 +1,0 @@
- source /cvmfs/sft.cern.ch/lcg/contrib/gcc/8.3.0/x86_64-centos7/setup.sh 
- source /cvmfs/geant4.cern.ch/geant4/10.7.p01/x86_64-centos7-gcc8-optdeb-MT/CMake-setup.sh 
- export CXX=`which g++`
- export CC=`which gcc`
- cmake3 -DGeant4_DIR= /cvmfs/geant4.cern.ch/geant4/10.7.p01/x86_64-centos7-gcc8-optdeb-MT/lib64/Geant4-10.7.1 ../DREMTubes/DREMTubes/
- make


### PR DESCRIPTION
This PR removes the scripts from the 2021 test beam (543a29e132abf6140f5a978e01ac55ef361eee7d).