### PR TITLE
Update in geometry: Hidra->Prototype and rotation

### DIFF
--- a/DRTB23Sim.cc
+++ b/DRTB23Sim.cc
@@ -33,7 +33,7 @@ namespace PrintUsageError {
     G4cerr << "->DREMTubes usage: " << G4endl;
     G4cerr << "DREMTubes [-m macro ] [-u UIsession] [-t nThreads] [-pl PhysicsList]" 
         << G4endl;
-    G4cerr << "          [-opt FullOptic]" << G4endl;
+    G4cerr << "          [-opt FullOptic] [-vert VerticalRotation]" << G4endl;
     }
 }
 
@@ -54,6 +54,7 @@ int main(int argc, char** argv) {
     G4String session;
     G4String custom_pl = "FTFP_BERT"; //default physics list
     G4bool FullOptic = false;
+    G4bool VertRot = false;
     #ifdef G4MULTITHREADED
     G4int nThreads = 0;
     #endif
@@ -64,6 +65,8 @@ int main(int argc, char** argv) {
         else if ( G4String(argv[i]) == "-pl") custom_pl = argv[i+1];
         else if ( G4String(argv[i]) == "-opt") FullOptic =  
                                             G4UIcommand::ConvertToBool(argv[i+1]);
+        else if ( G4String(argv[i]) == "-vert") VertRot = 
+                                            G4UIcommand::ConvertToBool(argv[i+1]); 
         #ifdef G4MULTITHREADED
         else if ( G4String(argv[i]) == "-t" ) {
             nThreads = G4UIcommand::ConvertToInt(argv[i+1]);
@@ -77,7 +80,12 @@ int main(int argc, char** argv) {
 
     //Print if FullOptic option is on
     //
-    if (FullOptic){ G4cout<<"DREMTubes-> Run with full optical description"<<G4endl; } 
+    if (FullOptic){ G4cout<<"DREMTubes-> Run with full optical description"<<G4endl; }
+
+    //Print if VertRot option is on
+    //
+    if (VertRot){ G4cout<<"DREMTubes-> Run with vertical rotation of calorimeter"<<G4endl; }
+
   
     // Detect interactive mode (if no macro provided) and define UI session
     //
@@ -99,7 +107,7 @@ int main(int argc, char** argv) {
 
     // Set mandatory initialization classes
     //
-    auto DetConstruction = new DREMTubesDetectorConstruction();
+    auto DetConstruction = new DREMTubesDetectorConstruction(VertRot);
     runManager->SetUserInitialization(DetConstruction);
 
     runManager->SetUserInitialization(new DREMTubesPhysicsList(custom_pl, FullOptic ));

--- a/README.md
+++ b/README.md
@@ -56,15 +56,16 @@ The project targets a standalone Geant4 simulation of the dual-readout electroma
    cmake -DGeant4_DIR=/absolute_path_to/geant4.10.07_p01-install/lib/Geant4-10.7.1/ relative_path_to/DRTB23Sim/
    make
    ```
-4. execute (example with DRTB23Sim_run.mac macro card, 2 thread, FTFP_BERT physics list and no optical propagation)
+4. execute (example with DRTB23Sim_run.mac macro card, 2 thread, FTFP_BERT physics list, no optical propagation, and no vertical rotation of the calorimeter)
    ```sh
-   ./DRTB23Sim -m DRTB23Sim_run.mac -t 2 -pl FTFP_BERT -opt false
+   ./DRTB23Sim -m DRTB23Sim_run.mac -t 2 -pl FTFP_BERT -opt false -vert false
    ```
 Parser options
    * -m macro.mac: pass a Geant4 macro card 
    * -t integer: pass number of threads for multi-thread execution (example -t 3, default t 2)
    * -pl Physics_List: select Geant4 physics list (example -pl FTFP_BERT)
    * -opt FullOptic: boolean variable to switch on (true) the optical photon propagation in fibers (example -opt true, default false)
+   * -vert VertRot: boolean to switch on (true) vertical rotation of the calorimeter (example -vert true, default false)
 
 ### Build, compile and execute on lxplus
 1. git clone the repo

--- a/include/DREMTubesDetectorConstruction.hh
+++ b/include/DREMTubesDetectorConstruction.hh
@@ -31,7 +31,7 @@ class DREMTubesDetectorConstruction : public G4VUserDetectorConstruction {
     public:
         //Constructor
         //
-        DREMTubesDetectorConstruction();
+        DREMTubesDetectorConstruction(const G4bool VerRot);
         //De-constructor
         //
         virtual ~DREMTubesDetectorConstruction();
@@ -95,6 +95,8 @@ class DREMTubesDetectorConstruction : public G4VUserDetectorConstruction {
 				
 				G4VPhysicalVolume* fLeakCntPV; //PV: lekage counter
 				G4VPhysicalVolume* fWorldPV;   //PV: wourld volume
+
+        G4bool fVertRot;  
 };
 
 inline G4int DREMTubesDetectorConstruction::GetTowerID( const G4int& cpno ) const {

--- a/include/DREMTubesGeoPar.hh
+++ b/include/DREMTubesGeoPar.hh
@@ -1,6 +1,6 @@
 #include "G4SystemOfUnits.hh"
 // TB2021 
-/*
+
     const G4int NofmodulesX = 3; 
     const G4int NofmodulesY = 3;
     const G4int modflag[9]={3,2,1,5,0,4,8,7,6};
@@ -11,8 +11,8 @@
     const G4int NoModulesActive=9;
     const G4double moduleZ = (1000.)*mm;
     const G4bool irot=false;
-*/
 
+/*
     const G4int NofmodulesX = 24; 
     const G4int NofmodulesY = 5;
     const G4int modflag[120]={-1,-1,-1,-1,-1,-1,-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9,-1,-1,-1,-1,-1,-1,-1,
@@ -27,5 +27,5 @@
     const G4int NoModulesActive=84;
     const G4double moduleZ = (2500.)*mm;
     const G4bool irot=true;
-
+*/
     const G4int NoFibersTower=NofFiberscolumn*NofFibersrow/2;

--- a/src/DREMTubesDetectorConstruction.cc
+++ b/src/DREMTubesDetectorConstruction.cc
@@ -576,10 +576,43 @@ G4VPhysicalVolume* DREMTubesDetectorConstruction::DefineVolumes() {
     position.setZ(0.);
     G4Transform3D transform = G4Transform3D(rotm,position); 
 
-    /*G4VPhysicalVolume* CalorimeterPV =*/ new G4PVPlacement(transform,
+    // Volumes for the rotating platform the TB prototype is placed on
+    G4Tubs* rotating_volume_solid = new G4Tubs("rotating_volume", 0, 1500*mm, 1000*mm, 0., 2.*pi);
+
+    G4LogicalVolume* rotating_volume_logical = new G4LogicalVolume( rotating_volume_solid,
+                                                          defaultMaterial,
+                                                          "rotating_volume_logical");
+
+    G4RotationMatrix rot_vol_rotmat  = G4RotationMatrix();
+    G4double rot_vol_xrot=90*deg;
+    rot_vol_rotmat.rotateX(rot_vol_xrot);
+    // Inverse rotation for calo to be pointed towards z 
+    //G4RotationMatrix calo_rotmat = G4RotationMatrix();
+    G4RotationMatrix calo_rotmat = rot_vol_rotmat.inverse();
+
+    // Further roation of volume
+    rot_vol_rotmat.rotateX(2.5*deg);
+
+    // Vertical rotation of module
+    calo_rotmat.rotateX(2.5*deg);
+
+    G4Transform3D rot_vol_transfm = G4Transform3D(rot_vol_rotmat, G4ThreeVector());  
+
+    /*G4VPhysicalVolume* rotating_volume_placed =*/ new G4PVPlacement(rot_vol_transfm,
+                                                                      rotating_volume_logical,
+                                                                      "RotatingVolume",
+                                                                      worldLV,
+                                                                      false,
+                                                                      0,
+                                                                      fCheckOverlaps);
+
+    
+    
+    G4Transform3D calo_transfm = G4Transform3D(calo_rotmat, G4ThreeVector()); 
+    /*G4VPhysicalVolume* CalorimeterPV =*/ new G4PVPlacement(calo_transfm,
                                                          CalorimeterLV,
                                                          "Calorimeter",
-                                                         worldLV,
+                                                         rotating_volume_logical,
                                                          false,
                                                          0,
                                                          fCheckOverlaps);

--- a/src/DREMTubesDetectorConstruction.cc
+++ b/src/DREMTubesDetectorConstruction.cc
@@ -50,11 +50,12 @@ const G4double sq3m1=sq3/3.;
 
 //Constructor
 //
-DREMTubesDetectorConstruction::DREMTubesDetectorConstruction()
+DREMTubesDetectorConstruction::DREMTubesDetectorConstruction(const G4bool VertRot)
     : G4VUserDetectorConstruction(),
     fCheckOverlaps(false),
 		fLeakCntPV(nullptr),
-    fWorldPV(nullptr){
+    fWorldPV(nullptr),
+    fVertRot(VertRot){
 }
 
 //De-constructor
@@ -635,9 +636,7 @@ G4VPhysicalVolume* DREMTubesDetectorConstruction::DefineVolumes() {
     G4RotationMatrix calo_rotmat = rot_vol_rotmat.inverse();
 
     // Vertical rotation of module
-    // TODO: implement as flag to be switched on and off
-    bool VerticalRotation = true;
-    double vert_rot = VerticalRotation ? -2.5*deg : 0.0*deg;
+    double vert_rot = fVertRot ? -2.5*deg : 0.0*deg;
     calo_rotmat.rotateX(vert_rot);
 
     double calo_shift = (air_volume_half_height-2*platform_half_height) - (-sin(vert_rot)*caloZ + cos(vert_rot)*caloY);

--- a/src/DREMTubesDetectorConstruction.cc
+++ b/src/DREMTubesDetectorConstruction.cc
@@ -579,8 +579,8 @@ G4VPhysicalVolume* DREMTubesDetectorConstruction::DefineVolumes() {
 
     // Volumes for implementing the rotating platform at the testbeam
     // Mother volume for platform and calo filled with air (defaultMaterial)
-    double platform_radius = 1500*mm;    // Radius guessed for now
-    double air_volume_half_height = 1000*mm; // More or less random, needs to be large enough to contain prototype
+    double platform_radius = 600*mm;    // Radius guessed for now
+    double air_volume_half_height = 200*mm; // More or less random, needs to be large enough to contain prototype
     G4Tubs* rotating_volume_solid = new G4Tubs("rotating_volume", 0, platform_radius, air_volume_half_height, 0., 2.*pi);
 
     G4LogicalVolume* rotating_volume_logical = new G4LogicalVolume( rotating_volume_solid,
@@ -609,7 +609,7 @@ G4VPhysicalVolume* DREMTubesDetectorConstruction::DefineVolumes() {
 
 
     // Volumes for the iron platform the prototype is placed on
-    double platform_half_height = 100*mm;     // Height guessed for now
+    double platform_half_height = 25*mm;     // Height guessed for now
     G4Material* platformMaterial = nistManager->FindOrBuildMaterial("G4_Fe");
     G4Tubs* iron_platform_solid = new G4Tubs("iron_platform", 0, platform_radius, platform_half_height, 0., 2.*pi);
 

--- a/src/DREMTubesDetectorConstruction.cc
+++ b/src/DREMTubesDetectorConstruction.cc
@@ -580,18 +580,11 @@ G4VPhysicalVolume* DREMTubesDetectorConstruction::DefineVolumes() {
     position.setZ(0.);
     G4Transform3D transform = G4Transform3D(rotm,position); 
 
-    /*****************************************************************
-    * Volumes for implementing the rotating platform at the testbeam *
-    ******************************************************************/ 
+    /***********************************************************
+    * Volumes for the iron platform the prototype is placed on *
+    ************************************************************/
 
-    // Mother volume for platform and calo filled with air (defaultMaterial)
     double platform_radius = 1200*mm;    // Radius guessed for now
-    double air_volume_half_height = 500*mm; // More or less random, needs to be large enough to contain prototype
-    G4Tubs* rotating_volume_solid = new G4Tubs("rotating_volume_solid", 0, platform_radius, air_volume_half_height, 0., 2.*pi);
-
-    G4LogicalVolume* rotating_volume_logical = new G4LogicalVolume( rotating_volume_solid,
-                                                                    defaultMaterial,
-                                                                    "rotating_volume_logical");
 
     // Rotation to bring the G4Tubs into the right Orientation
     G4RotationMatrix rot_vol_rotmat  = G4RotationMatrix();
@@ -599,25 +592,9 @@ G4VPhysicalVolume* DREMTubesDetectorConstruction::DefineVolumes() {
     rot_vol_rotmat.rotateX(rot_vol_xrot);
 
     // Horizontal rotation of the platform (including prototype)
-    G4RotationMatrix rot_vol_rotmat2  = G4RotationMatrix();
-    double horiz_rot = 10*deg;
-    rot_vol_rotmat2.rotateY(horiz_rot);
-
-    G4Transform3D rot_vol_transfm = G4Transform3D(rot_vol_rotmat2*rot_vol_rotmat, G4ThreeVector());  
-
-    /*G4VPhysicalVolume* rotating_volume_physical = new G4PVPlacement(rot_vol_transfm,
-                                                                        rotating_volume_logical,
-                                                                        "RotatingVolume",
-                                                                        worldLV,
-                                                                        false,
-                                                                        0,
-                                                                        fCheckOverlaps);*/
-
-
-
-    /***********************************************************
-    * Volumes for the iron platform the prototype is placed on *
-    ************************************************************/
+    G4RotationMatrix platform_rotmat  = G4RotationMatrix();
+    double horiz_rot = 0*deg;
+    platform_rotmat.rotateY(horiz_rot);
     double platform_half_height = 25*mm;     // Height guessed for now
     G4Material* platformMaterial = nistManager->FindOrBuildMaterial("G4_Fe");
     G4Tubs* iron_platform_solid = new G4Tubs("iron_platform_solid", 0, platform_radius, platform_half_height, 0., 2.*pi);
@@ -643,10 +620,6 @@ G4VPhysicalVolume* DREMTubesDetectorConstruction::DefineVolumes() {
     G4Box* subtract_bar = new G4Box("subtract_bar", bar_half_length, subtract_bar_height, subtract_bar_width);
 
     G4SubtractionSolid* bar_solid = new G4SubtractionSolid("bar_solid", outer_bar_solid, subtract_bar);
-
-    G4LogicalVolume* bar_logical = new G4LogicalVolume( bar_solid,
-                                                        aluminiumMaterial,
-                                                        "bar_logical");
 
     // Placement of bars is done with the housing. Some dimensions from the housing are needed
     
@@ -715,7 +688,7 @@ G4VPhysicalVolume* DREMTubesDetectorConstruction::DefineVolumes() {
     // Placement of iron platform because placement of calorimter should be relative to that
     double iron_plat_Y = -(caloY + bot_wall_thickness + 2*support_half_height + 2*bar_half_height + platform_half_height);
     G4ThreeVector iron_plat_pos = G4ThreeVector(0, iron_plat_Y, 0);
-    G4Transform3D iron_plat_transfm = G4Transform3D(rot_vol_rotmat2*rot_vol_rotmat, iron_plat_pos);
+    G4Transform3D iron_plat_transfm = G4Transform3D(platform_rotmat*rot_vol_rotmat, iron_plat_pos);
 
     /*G4VPhysicalVolume* iron_platform_physical =*/ new G4PVPlacement(iron_plat_transfm,
                                                                       iron_platform_logical,
@@ -749,7 +722,7 @@ G4VPhysicalVolume* DREMTubesDetectorConstruction::DefineVolumes() {
 
     G4ThreeVector fullbox_pos = G4ThreeVector(fullbox_X, fullbox_Y, fullbox_Z);
 
-    G4Transform3D fullbox_transfm = G4Transform3D(rot_vol_rotmat2*fullbox_rotmat, fullbox_pos); 
+    G4Transform3D fullbox_transfm = G4Transform3D(platform_rotmat*fullbox_rotmat, fullbox_pos); 
     /*G4VPhysicalVolume* fullbox_physical =*/ new G4PVPlacement(fullbox_transfm,
                                                                 fullbox_logical,
                                                                 "FullBox",
@@ -757,33 +730,6 @@ G4VPhysicalVolume* DREMTubesDetectorConstruction::DefineVolumes() {
                                                                 false,
                                                                 0,
                                                                 fCheckOverlaps);
-
-    
-                                                                    
-    /*
-    // Placement of two bars the housing rests on
-    G4Transform3D bar_front_transfm = G4Transform3D(G4RotationMatrix(), bar_front_pos);
-
-    G4ThreeVector bar_back_pos  = G4ThreeVector(0, (2*support_half_length-housing_half_length-bar_half_width-53*cm), bar_z);
-    G4Transform3D bar_back_transfm = G4Transform3D(G4RotationMatrix(), bar_back_pos);
-
-    G4VPhysicalVolume* bar_front_physical = new G4PVPlacement(bar_front_transfm,
-                                                                      bar_logical,
-                                                                      "Bar",
-                                                                      rotating_volume_logical,
-                                                                      false,
-                                                                      1,
-                                                                      fCheckOverlaps);
-                                                                             
-    /*G4VPhysicalVolume* bar_back_physical = new G4PVPlacement(bar_back_transfm,
-                                                                      bar_logical,
-                                                                      "Bar",
-                                                                      rotating_volume_logical,
-                                                                      false,
-                                                                      0,
-                                                                      fCheckOverlaps);   */
-    
-
 
 
     /**************

--- a/src/DREMTubesDetectorConstruction.cc
+++ b/src/DREMTubesDetectorConstruction.cc
@@ -586,11 +586,16 @@ G4VPhysicalVolume* DREMTubesDetectorConstruction::DefineVolumes() {
                                                                     defaultMaterial,
                                                                     "rotating_volume_logical");
 
+    // Rotation to bring the G4Tubs into the right Orientation
     G4RotationMatrix rot_vol_rotmat  = G4RotationMatrix();
     G4double rot_vol_xrot=90*deg;
     rot_vol_rotmat.rotateX(rot_vol_xrot);
 
-    G4Transform3D rot_vol_transfm = G4Transform3D(rot_vol_rotmat, G4ThreeVector());  
+    // Horizontal rotation of the platform (including prototype)
+    G4RotationMatrix rot_vol_rotmat2  = G4RotationMatrix();
+    rot_vol_rotmat2.rotateY(0*deg);
+
+    G4Transform3D rot_vol_transfm = G4Transform3D(rot_vol_rotmat2*rot_vol_rotmat, G4ThreeVector());  
 
     /*G4VPhysicalVolume* rotating_volume_placed =*/ new G4PVPlacement(rot_vol_transfm,
                                                                       rotating_volume_logical,
@@ -632,10 +637,10 @@ G4VPhysicalVolume* DREMTubesDetectorConstruction::DefineVolumes() {
     // Vertical rotation of module
     // TODO: implement as flag to be switched on and off
     bool VerticalRotation = true;
-    double vert_rot = VerticalRotation ? 2.5*deg : 0.0*deg;
+    double vert_rot = VerticalRotation ? -2.5*deg : 0.0*deg;
     calo_rotmat.rotateX(vert_rot);
 
-    double calo_shift = (air_volume_half_height-2*platform_half_height) - (sin(vert_rot)*caloZ + cos(vert_rot)*caloY);
+    double calo_shift = (air_volume_half_height-2*platform_half_height) - (-sin(vert_rot)*caloZ + cos(vert_rot)*caloY);
     G4ThreeVector calo_pos = G4ThreeVector(0, 0, calo_shift);
     
     


### PR DESCRIPTION
Moved from Hidra geometry to the TB21/23 geometry.

Introduced rotation of prototype in two directions:
- vertical: toggled via "-vert true/false" flag in command line. Currently hard-coded value of 2.5 degrees
- horizontal: Currently hard-coded value set to 0 degrees. Needs recompiling when chaning this value

Horizontal rotation is implemented via a rotating mother-volume for the calorimeter (air cylinder). For completeness the iron platform, on which the prototype now "rests", is also introduced in the simulation.
**IMPORTANT: With the current geometry the calorimeter is not centered on (0,0) in x-y-direction**