### PR TITLE
Adding GeoMessenger

### DIFF
--- a/include/DRTB23SimDetectorConstruction.hh
+++ b/include/DRTB23SimDetectorConstruction.hh
@@ -1,7 +1,9 @@
 //**************************************************
 // \file DRTB23SimDetectorConstruction.hh
-// \brief: Definition of DRTB23SimDetectorConstruction class
-// \author: Lorenzo Pezzotti (CERN EP-SFT-sim) @lopezzot
+// \brief: Definition of 
+//         DRTB23SimDetectorConstruction class
+// \author: Lorenzo Pezzotti (CERN EP-SFT-sim)
+//          @lopezzot
 // \start date: 7 July 2021
 //**************************************************
 
@@ -19,12 +21,14 @@
 #include "G4TwoVector.hh"
 #include "G4ExtrudedSolid.hh"
 
-//Include geometrical parameters
+//Includers from project files
+//
 #include "DRTB23SimGeoPar.hh"
+#include "DRTB23SimGeoMessenger.hh"
+
 //Forward declaration
 //
 class G4VPhysicalVolume;
-class G4GlobalMagFieldMessenger;
 
 class DRTB23SimDetectorConstruction : public G4VUserDetectorConstruction {
   
@@ -66,6 +70,17 @@ class DRTB23SimDetectorConstruction : public G4VUserDetectorConstruction {
     	//
 	const G4VPhysicalVolume* GetLeakCntPV() const;
     	const G4VPhysicalVolume* GetWorldPV() const;
+        G4double GetXshift() const {return fXshift;};
+        G4double GetYshift() const {return fYshift;};
+        G4double GetOrzrot() const {return fOrzrot;};
+        G4double GetVerrot() const {return fVerrot;};
+
+        //Setters
+        //
+        void SetXshift(const G4double& val) {fXshift=val;};
+        void SetYshift(const G4double& val) {fYshift=val;};
+        void SetOrzrot(const G4double& val) {fOrzrot=val;};
+        void SetVerrot(const G4double& val) {fVerrot=val;};
 
         //Other methods
 	//
@@ -73,9 +88,8 @@ class DRTB23SimDetectorConstruction : public G4VUserDetectorConstruction {
         G4int GetSiPMID(const G4int& cpno ) const; 
 	G4int GetSiPMTower(const G4int& town ) const;
        
-        //
-	//  Build contour in x-y plane of a module as 
-	//  an hexcell shape
+	//Build contour in x-y plane of a module as 
+	//an hexcell shape
 	//
 	std::vector<G4TwoVector> calcmod(double radius, int nrow, int ncol); 
 
@@ -84,19 +98,23 @@ class DRTB23SimDetectorConstruction : public G4VUserDetectorConstruction {
         //Mandatory method for Geant4
         //
         G4VPhysicalVolume* DefineVolumes();
-/*
-	void DefineCommands();
-	G4GenericMessenger* fMessenger;
-	G4double fAngleX;
-	G4double fAngleY;
-*/				//Members
-				//
+	
+        //Members
+	//
         G4bool  fCheckOverlaps; // option for checking volumes overlaps
 				
-				G4VPhysicalVolume* fLeakCntPV; //PV: lekage counter
-				G4VPhysicalVolume* fWorldPV;   //PV: wourld volume
+	G4VPhysicalVolume* fLeakCntPV; //PV: lekage counter
+	G4VPhysicalVolume* fWorldPV;   //PV: wourld volume
 
         G4bool fVertRot;  
+
+        //Pointer to messenger for UI
+        //
+        DRTB23SimGeoMessenger* fGeoMessenger;
+
+        //Parameters selectable via UI
+        //
+        G4double fXshift{0.}, fYshift{0.}, fVerrot{0.}, fOrzrot{0.};
 };
 
 inline G4int DRTB23SimDetectorConstruction::GetTowerID( const G4int& cpno ) const {

--- a/include/DRTB23SimGeoMessenger.hh
+++ b/include/DRTB23SimGeoMessenger.hh
@@ -1,0 +1,45 @@
+//**************************************************
+// \file DRTB23SimGeoMessenger.hh
+// \brief: Definition of DRTB23GeomMessenger class
+// \author: Lorenzo Pezzotti (CERN EP-SFT-sim)
+//          @lopezzot
+// \start date: 10 August 2023
+//**************************************************
+
+#ifndef DRTB23SimGeoMessenger_h
+#define DRTB23SimGeoMessenger_h 1
+
+//Includers from Geant4
+//
+#include "G4UImessenger.hh"
+#include "G4UIdirectory.hh"
+#include "G4UIcmdWithADoubleAndUnit.hh"
+
+//Includers from project files
+//
+class DRTB23SimDetectorConstruction;
+
+class DRTB23SimGeoMessenger final : public G4UImessenger {
+
+    public:
+        //Constructor and destructor
+        DRTB23SimGeoMessenger(DRTB23SimDetectorConstruction *DetConstruction);
+        ~DRTB23SimGeoMessenger();
+        
+        //Virtual methods from base class
+        void SetNewValue(G4UIcommand *command, G4String newValue) override;
+
+    private:
+        //Members
+        DRTB23SimDetectorConstruction *fDetConstruction;
+        G4UIdirectory *fMsgrDirectory;
+        G4UIcmdWithADoubleAndUnit *fXshiftcmd;
+        G4UIcmdWithADoubleAndUnit *fYshiftcmd;
+        G4UIcmdWithADoubleAndUnit *fOrzrotcmd;
+        G4UIcmdWithADoubleAndUnit *fVerrotcmd;
+
+};
+
+#endif //DRTB23SimGeoMessenger_h
+
+//**************************************************

--- a/src/DRTB23SimDetectorConstruction.cc
+++ b/src/DRTB23SimDetectorConstruction.cc
@@ -10,6 +10,7 @@
 //Includers from project files
 //
 #include "DRTB23SimDetectorConstruction.hh"
+#include "DRTB23SimGeoMessenger.hh"
 
 //Includers from Geant4
 //
@@ -42,7 +43,66 @@
 #include "G4SubtractionSolid.hh"
 #include "G4UnionSolid.hh"
 
+//Messenger constructor
 //
+DRTB23SimGeoMessenger::DRTB23SimGeoMessenger(DRTB23SimDetectorConstruction* DetConstruction)
+    : fDetConstruction(DetConstruction){
+    
+    //The Messenger directory and commands must be initialized
+    //within constructor
+    //
+    fMsgrDirectory = new G4UIdirectory("/tbgeo/");
+    fMsgrDirectory->SetGuidance("Set movable parameters in test-beam geometry.");
+
+    fXshiftcmd = new G4UIcmdWithADoubleAndUnit("/tbgeo/xshift", this);
+    fXshiftcmd->SetGuidance("Shift test-beam platform x direction (default unit mm)");
+    fXshiftcmd->SetDefaultUnit("mm");
+    fYshiftcmd = new G4UIcmdWithADoubleAndUnit("/tbgeo/yshift", this);
+    fYshiftcmd->SetGuidance("Shift test-beam platform y direction (default unit mm)");
+    fYshiftcmd->SetDefaultUnit("mm");
+    fOrzrotcmd = new G4UIcmdWithADoubleAndUnit("/tbgeo/orlrot", this);
+    fOrzrotcmd->SetGuidance("Rotate platform (default deg)");
+    fOrzrotcmd->SetDefaultUnit("deg");
+    fVerrotcmd = new G4UIcmdWithADoubleAndUnit("/tbgeo/verrot", this);
+    fVerrotcmd->SetGuidance("Lift up calorimeter from back side (default deg)");
+    fVerrotcmd->SetDefaultUnit("deg");
+}
+
+//Messenger destructor
+//
+DRTB23SimGeoMessenger::~DRTB23SimGeoMessenger(){
+
+    //The Messenger fields should be deleted
+    //in destructor
+    delete fMsgrDirectory;
+    delete fXshiftcmd;
+    delete fYshiftcmd;
+    delete fOrzrotcmd;
+    delete fVerrotcmd;
+}
+
+//Messenger SetNewValue virtual method from base class
+//
+void DRTB23SimGeoMessenger::SetNewValue(G4UIcommand* command, G4String newValue){
+
+    if(command == fXshiftcmd){
+        fDetConstruction->SetXshift(fXshiftcmd->GetNewDoubleValue(newValue));
+        G4cout<<"tbgeo: x-shifted test-beam setup by "<<fDetConstruction->GetXshift()<<" mm"<<G4endl;
+    }
+    else if(command == fYshiftcmd){
+        fDetConstruction->SetYshift(fYshiftcmd->GetNewDoubleValue(newValue));
+        G4cout<<"tbgeo: y-shifted test-beam setup by "<<fDetConstruction->GetYshift()<<" mm"<<G4endl;
+    }
+    else if(command == fOrzrotcmd){
+        fDetConstruction->SetOrzrot(fOrzrotcmd->GetNewDoubleValue(newValue));
+        G4cout<<"tbgeo: orz-rotated test-beam setup by "<<fDetConstruction->GetOrzrot()<<" rad"<<G4endl;
+    }
+    else if(command == fVerrotcmd){
+        fDetConstruction->SetVerrot(fVerrotcmd->GetNewDoubleValue(newValue));
+        G4cout<<"tbgeo: ver-rotated test-beam setup by "<<fDetConstruction->GetVerrot()<<" rad"<<G4endl;
+    }
+}
+
 //  sqrt3 constants used in code
 //  reciprocal of sqrt3 given as number that divided 
 //  by sqrt 3 gives 3 
@@ -55,9 +115,11 @@ const G4double sq3m1=sq3/3.;
 DRTB23SimDetectorConstruction::DRTB23SimDetectorConstruction(const G4bool VertRot)
     : G4VUserDetectorConstruction(),
     fCheckOverlaps(false),
-		fLeakCntPV(nullptr),
+    fLeakCntPV(nullptr),
     fWorldPV(nullptr),
     fVertRot(VertRot){
+
+    fGeoMessenger = new DRTB23SimGeoMessenger(this);
 }
 
 //De-constructor


### PR DESCRIPTION
Adding the first implementation of a G4UIMessenger to handle the free parameters of the test-beam geometry. Not effective for now but compiles and sets values correctly.