### PR TITLE
Make /tbgeo parameters effective

### DIFF
--- a/DRTB23Sim.cc
+++ b/DRTB23Sim.cc
@@ -129,10 +129,15 @@ int main(int argc, char** argv) {
         G4String command = "/control/execute ";
         UImanager->ApplyCommand(command+macro);
     }
-    else  { //start UI session  
-    UImanager->ApplyCommand("/control/execute DRTB23Sim_init_vis.mac");
+    else{ //start UI session  
+        //UImanager->ApplyCommand("/control/execute DRTB23Sim_init_vis.mac");
+        //do not initialize run and visualization
+        //in main function; /tbgeo parameters should be
+        //initialized first.
+        //Instead intialize them and then type
+        //in GUI /control/execute DRTB23Sim_init_vis.mac
     if (ui->IsGUI()) {
-      UImanager->ApplyCommand("/control/execute DRTB23Sim_gui.mac");
+        UImanager->ApplyCommand("/control/execute DRTB23Sim_gui.mac");
     }
     ui->SessionStart();
     delete ui;

--- a/DRTB23Sim_init_vis.mac
+++ b/DRTB23Sim_init_vis.mac
@@ -1,3 +1,12 @@
+#Uncomment the /tbgeo paramenters below for geometry visualization
+#with non-default parameters
+#/tbgeo/xshift x mm
+#/tbgeo/yshift y mm
+#/tbgeo/horizrot theta deg
+#/tbgeo/verttot phi deg
+#or open the simulation in vis-gui mode (./DRTB23Sim)
+#pass the /tbgeo parameters and then call this macro
+#(/control/execute DRTB23Sim_init_vis.mac)
 #
 # Macro file for the initialization visualization settings
 # in interactive session

--- a/src/DRTB23SimDetectorConstruction.cc
+++ b/src/DRTB23SimDetectorConstruction.cc
@@ -60,10 +60,10 @@ DRTB23SimGeoMessenger::DRTB23SimGeoMessenger(DRTB23SimDetectorConstruction* DetC
     fYshiftcmd = new G4UIcmdWithADoubleAndUnit("/tbgeo/yshift", this);
     fYshiftcmd->SetGuidance("Shift test-beam platform y direction (default unit mm)");
     fYshiftcmd->SetDefaultUnit("mm");
-    fOrzrotcmd = new G4UIcmdWithADoubleAndUnit("/tbgeo/orlrot", this);
+    fOrzrotcmd = new G4UIcmdWithADoubleAndUnit("/tbgeo/horizrot", this);
     fOrzrotcmd->SetGuidance("Rotate platform (default deg)");
     fOrzrotcmd->SetDefaultUnit("deg");
-    fVerrotcmd = new G4UIcmdWithADoubleAndUnit("/tbgeo/verrot", this);
+    fVerrotcmd = new G4UIcmdWithADoubleAndUnit("/tbgeo/vertrot", this);
     fVerrotcmd->SetGuidance("Lift up calorimeter from back side (default deg)");
     fVerrotcmd->SetDefaultUnit("deg");
 }
@@ -464,8 +464,8 @@ G4VPhysicalVolume* DRTB23SimDetectorConstruction::DefineVolumes() {
     G4Box*            stage_solid   = new G4Box("stage_solid", platform_radius, platform_radius, platform_radius);
     G4LogicalVolume*  stage_logical = new G4LogicalVolume(stage_solid, defaultMaterial, "stage_logical");
     stage_logical->SetVisAttributes(G4VisAttributes::Invisible);
-    G4double stage_x = 0.0*CLHEP::mm;
-    G4double stage_y = 0.0*CLHEP::mm;
+    G4double stage_x = fXshift; //set via G4UIMessenger, default=0.
+    G4double stage_y = fYshift; //set via G4UIMessenger, default=0.
     /*G4VPhysicalVolume* stage_physical =*/ new G4PVPlacement(0,                // no rotation
                                                               G4ThreeVector(stage_x,stage_y, 0),
                                                               stage_logical,    // its logical
@@ -660,7 +660,7 @@ G4VPhysicalVolume* DRTB23SimDetectorConstruction::DefineVolumes() {
 
     // Horizontal rotation of the platform (including prototype)
     G4RotationMatrix platform_rotmat  = G4RotationMatrix();
-    double horiz_rot = 0*deg;
+    double horiz_rot = fOrzrot; //set via G4UIMessenger, default=0.
     platform_rotmat.rotateY(horiz_rot);
     G4Material* platformMaterial = nistManager->FindOrBuildMaterial("G4_Fe");
     G4Tubs* iron_platform_solid = new G4Tubs("iron_platform_solid", 0, platform_radius, platform_half_height, 0., 2.*pi);
@@ -762,7 +762,10 @@ G4VPhysicalVolume* DRTB23SimDetectorConstruction::DefineVolumes() {
     //G4RotationMatrix fullbox_rotmat = rot_vol_rotmat.inverse();
     G4RotationMatrix fullbox_rotmat = G4RotationMatrix();
     // Vertical rotation of module
-    double vert_rot = fVertRot ? -2.5*deg : 0.0*deg;
+    //double vert_rot = fVertRot ? -2.5*deg : 0.0*deg; //to be removed
+    double vert_rot = -fVerrot; //set via G4UIMessenger, default=0.
+                                //- sign needed to rotate as
+                                //done at the test-beam.
     fullbox_rotmat.rotateX(vert_rot);
 
     


### PR DESCRIPTION
This PR makes the /tbgeo parameters selectable with the G4UIMessenger effective in the geometry constructions. The user should use them as 
```
/tbgeo/xshift <> [<Unit>]
/tbgeo/yshift <> [<Unit>]
/tbgeo/horizrot <> [<Unit>]
/tbgeo/vertrot <> [<Unit>]
```
The default parameters value is 0.
Note: parameters should be initialized before the initialization of the run, i.e. before the call to `/run/initialize/`. In GUI mode, select the parameters first, then call `/control/execute DRTB23Sim_init_vis.mac` for run and vis initialization.