### PR TITLE
Added fibre attenuation to simulation

### DIFF
--- a/DRTB23Sim_run.mac
+++ b/DRTB23Sim_run.mac
@@ -21,7 +21,7 @@
 /gps/pos/type Plane
 /gps/pos/shape Circle
 /gps/pos/radius 0.01 cm
-/random/setSeeds 1.2 2.5
+/random/setSeeds 12 25
 #
 # Run:
 #

--- a/include/DRTB23SimSignalHelper.hh
+++ b/include/DRTB23SimSignalHelper.hh
@@ -22,6 +22,11 @@ class DRTB23SimSignalHelper {
 
         static DRTB23SimSignalHelper* instance;
 
+		const G4double fk_B = 0.126; //Birks constant
+
+		const G4double fSAttenuationLength = 191.6*CLHEP::cm; // from test beam data
+		const G4double fCAttenuationLength = 388.9*CLHEP::cm; // from test beam data
+
 	//Private constructor (singleton)
         //
 	DRTB23SimSignalHelper();

--- a/include/DRTB23SimSignalHelper.hh
+++ b/include/DRTB23SimSignalHelper.hh
@@ -14,6 +14,7 @@
 //Includers from Geant4
 //
 #include "globals.hh"
+#include "G4Step.hh"
 
 class DRTB23SimSignalHelper {
 
@@ -35,6 +36,13 @@ class DRTB23SimSignalHelper {
 
     	G4int SmearCSignal( );
 
+		G4double GetDistanceToSiPM(const G4Step* step);
+
+		G4int AttenuateHelper(const G4int& signal, const G4double& distance, const G4double& attenuation_length);
+
+		G4int AttenuateSSignal(const G4int& signal, const G4double& distance);
+
+		G4int AttenuateCSignal(const G4int& signal, const G4double& distance);
 };
 
 #endif

--- a/src/DRTB23SimSignalHelper.cc
+++ b/src/DRTB23SimSignalHelper.cc
@@ -39,8 +39,7 @@ DRTB23SimSignalHelper* DRTB23SimSignalHelper::Instance(){
 //
 G4double DRTB23SimSignalHelper::ApplyBirks( const G4double& de, const G4double& steplength ) {
 		
-    const G4double k_B = 0.126; //Birks constant
-    return (de/steplength) / ( 1+k_B*(de/steplength) ) * steplength;
+    return (de/steplength) / ( 1+fk_B*(de/steplength) ) * steplength;
 
 }
 
@@ -110,8 +109,7 @@ G4int DRTB23SimSignalHelper::AttenuateHelper(const G4int& signal, const G4double
 //
 G4int DRTB23SimSignalHelper::AttenuateSSignal(const G4int& signal, const G4double& distance) {
 
-    G4double attenuation_length = 191.6*CLHEP::cm; // from test beam data
-    return AttenuateHelper(signal, distance, attenuation_length);    
+    return AttenuateHelper(signal, distance, fSAttenuationLength);    
 
 }
 
@@ -119,8 +117,7 @@ G4int DRTB23SimSignalHelper::AttenuateSSignal(const G4int& signal, const G4doubl
 //
 G4int DRTB23SimSignalHelper::AttenuateCSignal(const G4int& signal, const G4double& distance) {
 
-    G4double attenuation_length = 388.9*CLHEP::cm; // from test beam data
-    return AttenuateHelper(signal, distance, attenuation_length);    
+    return AttenuateHelper(signal, distance, fCAttenuationLength);    
     
 }
 

--- a/src/DRTB23SimSignalHelper.cc
+++ b/src/DRTB23SimSignalHelper.cc
@@ -13,6 +13,12 @@
 
 //Includers from Geant4
 #include "G4Poisson.hh"
+#include "G4Tubs.hh"
+#include "G4NavigationHistory.hh"
+
+//Includers from C++
+//
+#include <random>
 
 DRTB23SimSignalHelper* DRTB23SimSignalHelper::instance = 0;
 
@@ -52,6 +58,70 @@ G4int DRTB23SimSignalHelper::SmearCSignal( ){
 		
     return G4Poisson(0.153);
 
+}
+
+//Define GetDistanceToSiPM() method
+//
+G4double DRTB23SimSignalHelper::GetDistanceToSiPM(const G4Step* step) {
+
+    // Get the pre-step point
+    const G4StepPoint* preStepPoint = step->GetPreStepPoint();
+    // Get the global position of the pre-step point
+    G4ThreeVector globalPos = preStepPoint->GetPosition();
+    // Get the local position of the pre-step point in the current volume's coordinate system
+    G4ThreeVector localPos = preStepPoint->GetTouchableHandle()->GetHistory()->GetTopTransform().TransformPoint(globalPos);
+    // G4cout << "Local Position (X,Y,Z): (" << localPos.x()/CLHEP::mm << ", " << localPos.y()/CLHEP::mm << ", " << localPos.z()/CLHEP::mm << ") mm" << G4endl;
+
+    // Get the logical volume of the current step
+    G4LogicalVolume* currentVolume = preStepPoint->GetTouchableHandle()->GetVolume()->GetLogicalVolume();
+    // Get the solid associated with the logical volume
+    G4Tubs* solid = dynamic_cast<G4Tubs*>(currentVolume->GetSolid());
+    // Get the dimensions of the solid (size of the volume)
+    G4double size = solid->GetZHalfLength();
+
+    G4double distance_to_sipm = size - localPos.z();
+    return distance_to_sipm;
+
+}
+
+//Define AttenuateHelper() method
+G4int DRTB23SimSignalHelper::AttenuateHelper(const G4int& signal, const G4double& distance, const G4double& attenuation_length) {
+    double probability_of_survival = exp(-distance/attenuation_length);
+
+    // Seed the random number generator
+    std::random_device rd;
+    std::default_random_engine rng(rd());
+
+    // Define the distribution with the given probability x
+    std::uniform_real_distribution<double> dist(0.0, 1.0);
+
+    G4int survived_photons = 0;
+    for (int i=0; i<signal; i++)
+    {
+        // Simulate drawing between 0 and 1 with probability x of getting 1
+        if (dist(rng) <= probability_of_survival) survived_photons++;
+    }
+
+    return survived_photons;
+
+}
+
+//Define AttenuateSSignal() method
+//
+G4int DRTB23SimSignalHelper::AttenuateSSignal(const G4int& signal, const G4double& distance) {
+
+    G4double attenuation_length = 191.6*CLHEP::cm; // from test beam data
+    return AttenuateHelper(signal, distance, attenuation_length);    
+
+}
+
+//Define AttenuateCSignal() method
+//
+G4int DRTB23SimSignalHelper::AttenuateCSignal(const G4int& signal, const G4double& distance) {
+
+    G4double attenuation_length = 388.9*CLHEP::cm; // from test beam data
+    return AttenuateHelper(signal, distance, attenuation_length);    
+    
 }
 
 //**************************************************

--- a/src/DRTB23SimSignalHelper.cc
+++ b/src/DRTB23SimSignalHelper.cc
@@ -18,7 +18,7 @@
 
 //Includers from C++
 //
-#include <random>
+// #include <random>
 
 DRTB23SimSignalHelper* DRTB23SimSignalHelper::instance = 0;
 
@@ -87,18 +87,11 @@ G4double DRTB23SimSignalHelper::GetDistanceToSiPM(const G4Step* step) {
 G4int DRTB23SimSignalHelper::AttenuateHelper(const G4int& signal, const G4double& distance, const G4double& attenuation_length) {
     double probability_of_survival = exp(-distance/attenuation_length);
 
-    // Seed the random number generator
-    std::random_device rd;
-    std::default_random_engine rng(rd());
-
-    // Define the distribution with the given probability x
-    std::uniform_real_distribution<double> dist(0.0, 1.0);
-
     G4int survived_photons = 0;
     for (int i=0; i<signal; i++)
     {
         // Simulate drawing between 0 and 1 with probability x of getting 1
-        if (dist(rng) <= probability_of_survival) survived_photons++;
+        if (G4UniformRand() <= probability_of_survival) survived_photons++;
     }
 
     return survived_photons;

--- a/src/DRTB23SimSteppingAction.cc
+++ b/src/DRTB23SimSteppingAction.cc
@@ -131,11 +131,16 @@ void DRTB23SimSteppingAction::FastSteppingAction( const G4Step* step ) {
 //    G4VPhysicalVolume* modvolume 
 //        = step->GetPreStepPoint()->GetTouchableHandle()->GetVolume(3);
 //	 std::cout << " grandmother name " << modvolume->GetName() << " number " << modvolume->GetCopyNo() << std::endl;
-//        std::cout << " grandmother nunber " << step->GetPreStepPoint()->GetTouchableHandle()->GetCopyNumber(3) << std::endl;			 
+//        std::cout << " grandmother nunber " << step->GetPreStepPoint()->GetTouchableHandle()->GetCopyNumber(3) << std::endl;
+
+    G4double distance_to_sipm = fSignalHelper->GetDistanceToSiPM(step);
+
 	TowerID = fDetConstruction->GetTowerID(step->GetPreStepPoint()->GetTouchableHandle()->GetCopyNumber(3));
 	SiPMTower=fDetConstruction->GetSiPMTower(TowerID);
 	fEventAction->AddScin(edep);
 	signalhit = fSignalHelper->SmearSSignal( fSignalHelper->ApplyBirks( edep, steplength ) );
+    // Attenuate Signal
+    signalhit = fSignalHelper->AttenuateSSignal(signalhit, distance_to_sipm);
 //	if ( TowerID != 0 ) { fEventAction->AddVecSPMT( TowerID, signalhit ); }
 	fEventAction->AddVecSPMT( TowerID, signalhit ); 
 	if(SiPMTower > -1){ 
@@ -168,7 +173,10 @@ void DRTB23SimSteppingAction::FastSteppingAction( const G4Step* step ) {
 	    switch ( theStatus ){
 								
 	        case TotalInternalReflection: {
-		    G4int c_signal = fSignalHelper->SmearCSignal( );								
+            G4double distance_to_sipm = fSignalHelper->GetDistanceToSiPM(step);
+		    G4int c_signal = fSignalHelper->SmearCSignal( );
+            // Attenuate Signal
+            c_signal = fSignalHelper->AttenuateCSignal(c_signal, distance_to_sipm);								
 		    TowerID = fDetConstruction->GetTowerID(step->GetPreStepPoint()->GetTouchableHandle()->GetCopyNumber(3));		
 	            SiPMTower=fDetConstruction->GetSiPMTower(TowerID);
 		    fEventAction->AddVecCPMT( TowerID, c_signal );


### PR DESCRIPTION
Fibre attenuation based on test beam data is simulated. For each photon emission a probabilty of survival is calculated based on an exponential decay. Survival of each photon is drawn with this probability which is determined via the distance from creation to SiPM (end of fibre) For distance to SiPM only the z information of the step along the fibre is used.