### PR TITLE
New SteppingAction

### DIFF
--- a/DRTB23Sim.cc
+++ b/DRTB23Sim.cc
@@ -115,7 +115,7 @@ int main(int argc, char** argv) {
     PhysicsList->RegisterPhysics( OpPhysics );
     runManager->SetUserInitialization(PhysicsList);
  
-    auto actionInitialization = new DRTB23SimActionInitialization( DetConstruction );
+    auto actionInitialization = new DRTB23SimActionInitialization;
     runManager->SetUserInitialization(actionInitialization); //Actions
   
     // Initialize visualization

--- a/DRTB23Sim_run.mac
+++ b/DRTB23Sim_run.mac
@@ -8,7 +8,13 @@
 # Change the default number of workers (in multi-threading mode) 
 #/run/numberOfWorkers 4
 #
+# Do not show list of processes
+#
+/process/em/verbose 0
+/process/had/verbose 0
+#
 # Initialize kernel
+#
 /run/initialize
 #
 # Kinematics: 

--- a/include/DRTB23SimActionInitialization.hh
+++ b/include/DRTB23SimActionInitialization.hh
@@ -24,15 +24,11 @@ class DRTB23SimActionInitialization : public G4VUserActionInitialization {
     public:
         //Constructor
         //
-        DRTB23SimActionInitialization(DRTB23SimDetectorConstruction* );
+        DRTB23SimActionInitialization();
         virtual ~DRTB23SimActionInitialization();
 
         virtual void BuildForMaster() const;
         virtual void Build() const;
-
-    private:
-
-	DRTB23SimDetectorConstruction* fDetConstruction;
 
 };
 

--- a/include/DRTB23SimDetectorConstruction.hh
+++ b/include/DRTB23SimDetectorConstruction.hh
@@ -88,12 +88,6 @@ class DRTB23SimDetectorConstruction : public G4VUserDetectorConstruction {
         void SetOrzrot(const G4double& val) {fOrzrot=val;};
         void SetVerrot(const G4double& val) {fVerrot=val;};
 
-        //Other methods
-	//
-	G4int GetTowerID( const G4int& cpno ) const;
-        G4int GetSiPMID(const G4int& cpno ) const; 
-	G4int GetSiPMTower(const G4int& town ) const;
-       
 	//Build contour in x-y plane of a module as 
 	//an hexcell shape
 	//
@@ -127,28 +121,6 @@ class DRTB23SimDetectorConstruction : public G4VUserDetectorConstruction {
         //
         G4double fXshift{0.}, fYshift{0.}, fVerrot{0.}, fOrzrot{0.};
 };
-
-inline G4int DRTB23SimDetectorConstruction::GetTowerID( const G4int& cpno ) const {
-// remap as for 2021 hardware numbering from front face
-//    const G4int idmap[9]={1,2,3,4,0,5,6,7,8};
-// test:remap as for output of old simulation
-//    const G4int idmap[9]={3,2,1,5,0,4,8,7,6};
-//    return idmap[cpno-1];
-    return cpno;		
-}
-
-inline G4int DRTB23SimDetectorConstruction::GetSiPMID( const G4int& cpno ) const {
-// kept for compatibility with old simulation. Dummy for now
-    return cpno;		
-}
-
-inline G4int DRTB23SimDetectorConstruction::GetSiPMTower( const G4int& town ) const {
-    G4int SiPMTower=-1;
-    for(int i=0;i<NoModulesSiPM;i++){
-      if(town==SiPMMod[i])SiPMTower=i;
-    }
-    return SiPMTower;		
-}
 
 #endif
 

--- a/include/DRTB23SimDetectorConstruction.hh
+++ b/include/DRTB23SimDetectorConstruction.hh
@@ -67,9 +67,9 @@ class DRTB23SimDetectorConstruction : public G4VUserDetectorConstruction {
                                             G4Material* CladCherMaterial);
         //Getters
     	//
-    	G4VPhysicalVolume* GetWorldPV() const;
-    	G4VPhysicalVolume* GetPSPV() const;
-    	G4VPhysicalVolume* GetPSScinPV() const;
+    	G4VPhysicalVolume* GetWorldPV() const {return fWorldPV;};
+    	G4VPhysicalVolume* GetPSPV() const {return fPSPV;};
+    	G4VPhysicalVolume* GetPSScinPV() const {return fPSScinPV;};
     	G4LogicalVolume* GetSAbsLV() const {return fSfiber_Abs_LV;};
     	G4LogicalVolume* GetSCoreLV() const {return fSfiber_Core_LV;};
     	G4LogicalVolume* GetSCladLV() const {return fSfiber_Clad_LV;};
@@ -148,18 +148,6 @@ inline G4int DRTB23SimDetectorConstruction::GetSiPMTower( const G4int& town ) co
       if(town==SiPMMod[i])SiPMTower=i;
     }
     return SiPMTower;		
-}
-
-inline G4VPhysicalVolume* DRTB23SimDetectorConstruction::GetWorldPV() const {
-    return fWorldPV;
-}
-
-inline G4VPhysicalVolume* DRTB23SimDetectorConstruction::GetPSPV() const {
-    return fPSPV;
-}
-
-inline G4VPhysicalVolume* DRTB23SimDetectorConstruction::GetPSScinPV() const {
-    return fPSScinPV;
 }
 
 #endif

--- a/include/DRTB23SimDetectorConstruction.hh
+++ b/include/DRTB23SimDetectorConstruction.hh
@@ -67,9 +67,15 @@ class DRTB23SimDetectorConstruction : public G4VUserDetectorConstruction {
                                             G4Material* CladCherMaterial);
         //Getters
     	//
-    	const G4VPhysicalVolume* GetWorldPV() const;
-    	const G4VPhysicalVolume* GetPSPV() const;
-    	const G4VPhysicalVolume* GetPSScinPV() const;
+    	G4VPhysicalVolume* GetWorldPV() const;
+    	G4VPhysicalVolume* GetPSPV() const;
+    	G4VPhysicalVolume* GetPSScinPV() const;
+    	G4LogicalVolume* GetSAbsLV() const {return fSfiber_Abs_LV;};
+    	G4LogicalVolume* GetSCoreLV() const {return fSfiber_Core_LV;};
+    	G4LogicalVolume* GetSCladLV() const {return fSfiber_Clad_LV;};
+    	G4LogicalVolume* GetCAbsLV() const {return fCfiber_Abs_LV;};
+    	G4LogicalVolume* GetCCoreLV() const {return fCfiber_Core_LV;};
+    	G4LogicalVolume* GetCCladLV() const {return fCfiber_Clad_LV;};
         G4double GetXshift() const {return fXshift;};
         G4double GetYshift() const {return fYshift;};
         G4double GetOrzrot() const {return fOrzrot;};
@@ -106,6 +112,12 @@ class DRTB23SimDetectorConstruction : public G4VUserDetectorConstruction {
 	G4VPhysicalVolume* fWorldPV; //PV: world volume
         G4VPhysicalVolume* fPSPV; //PV: preshower volume
         G4VPhysicalVolume* fPSScinPV; //PV: preshower scintillator volume
+        G4LogicalVolume*   fSfiber_Abs_LV; //LV: Absorber of S fiber
+        G4LogicalVolume*   fSfiber_Core_LV; //LV: Core of S fiber
+        G4LogicalVolume*   fSfiber_Clad_LV; //LV: Cladding of S fiber
+        G4LogicalVolume*   fCfiber_Abs_LV; //LV: Absorber of C fiber
+        G4LogicalVolume*   fCfiber_Core_LV; //LV: Core of C fiber
+        G4LogicalVolume*   fCfiber_Clad_LV; //LV: Cladding of C fiber
 
         //Pointer to messenger for UI
         //
@@ -138,15 +150,15 @@ inline G4int DRTB23SimDetectorConstruction::GetSiPMTower( const G4int& town ) co
     return SiPMTower;		
 }
 
-inline const G4VPhysicalVolume* DRTB23SimDetectorConstruction::GetWorldPV() const {
+inline G4VPhysicalVolume* DRTB23SimDetectorConstruction::GetWorldPV() const {
     return fWorldPV;
 }
 
-inline const G4VPhysicalVolume* DRTB23SimDetectorConstruction::GetPSPV() const {
+inline G4VPhysicalVolume* DRTB23SimDetectorConstruction::GetPSPV() const {
     return fPSPV;
 }
 
-inline const G4VPhysicalVolume* DRTB23SimDetectorConstruction::GetPSScinPV() const {
+inline G4VPhysicalVolume* DRTB23SimDetectorConstruction::GetPSScinPV() const {
     return fPSScinPV;
 }
 

--- a/include/DRTB23SimDetectorConstruction.hh
+++ b/include/DRTB23SimDetectorConstruction.hh
@@ -44,8 +44,7 @@ class DRTB23SimDetectorConstruction : public G4VUserDetectorConstruction {
     public:
         virtual G4VPhysicalVolume* Construct();
 
-        G4LogicalVolume* constructscinfiber(double tolerance,
-                                            G4double tuberadius,
+        G4LogicalVolume* constructscinfiber(G4double tuberadius,
                                             G4double fiberZ,
                                             G4Material* absorberMaterial,
                                             G4double coreradius,
@@ -56,8 +55,7 @@ class DRTB23SimDetectorConstruction : public G4VUserDetectorConstruction {
                                             G4double claddingZ,
                                             G4Material* CherMaterial);
     
-        G4LogicalVolume* constructcherfiber(double tolerance, 
-                                            G4double tuberadius,
+        G4LogicalVolume* constructcherfiber(G4double tuberadius,
                                             G4double fiberZ,
                                             G4Material* absorberMaterial,
                                             G4double coreradius,

--- a/include/DRTB23SimDetectorConstruction.hh
+++ b/include/DRTB23SimDetectorConstruction.hh
@@ -70,6 +70,8 @@ class DRTB23SimDetectorConstruction : public G4VUserDetectorConstruction {
         //Getters
     	//
     	const G4VPhysicalVolume* GetWorldPV() const;
+    	const G4VPhysicalVolume* GetPSPV() const;
+    	const G4VPhysicalVolume* GetPSScinPV() const;
         G4double GetXshift() const {return fXshift;};
         G4double GetYshift() const {return fYshift;};
         G4double GetOrzrot() const {return fOrzrot;};
@@ -103,7 +105,9 @@ class DRTB23SimDetectorConstruction : public G4VUserDetectorConstruction {
 	//
         G4bool  fCheckOverlaps; // option for checking volumes overlaps
 				
-	G4VPhysicalVolume* fWorldPV; //PV: wourld volume
+	G4VPhysicalVolume* fWorldPV; //PV: world volume
+        G4VPhysicalVolume* fPSPV; //PV: preshower volume
+        G4VPhysicalVolume* fPSScinPV; //PV: preshower scintillator volume
 
         //Pointer to messenger for UI
         //
@@ -138,6 +142,14 @@ inline G4int DRTB23SimDetectorConstruction::GetSiPMTower( const G4int& town ) co
 
 inline const G4VPhysicalVolume* DRTB23SimDetectorConstruction::GetWorldPV() const {
     return fWorldPV;
+}
+
+inline const G4VPhysicalVolume* DRTB23SimDetectorConstruction::GetPSPV() const {
+    return fPSPV;
+}
+
+inline const G4VPhysicalVolume* DRTB23SimDetectorConstruction::GetPSScinPV() const {
+    return fPSScinPV;
 }
 
 #endif

--- a/include/DRTB23SimDetectorConstruction.hh
+++ b/include/DRTB23SimDetectorConstruction.hh
@@ -69,7 +69,6 @@ class DRTB23SimDetectorConstruction : public G4VUserDetectorConstruction {
                                             G4Material* CladCherMaterial);
         //Getters
     	//
-	const G4VPhysicalVolume* GetLeakCntPV() const;
     	const G4VPhysicalVolume* GetWorldPV() const;
         G4double GetXshift() const {return fXshift;};
         G4double GetYshift() const {return fYshift;};
@@ -104,8 +103,7 @@ class DRTB23SimDetectorConstruction : public G4VUserDetectorConstruction {
 	//
         G4bool  fCheckOverlaps; // option for checking volumes overlaps
 				
-	G4VPhysicalVolume* fLeakCntPV; //PV: lekage counter
-	G4VPhysicalVolume* fWorldPV;   //PV: wourld volume
+	G4VPhysicalVolume* fWorldPV; //PV: wourld volume
 
         //Pointer to messenger for UI
         //
@@ -136,10 +134,6 @@ inline G4int DRTB23SimDetectorConstruction::GetSiPMTower( const G4int& town ) co
       if(town==SiPMMod[i])SiPMTower=i;
     }
     return SiPMTower;		
-}
-
-inline const G4VPhysicalVolume* DRTB23SimDetectorConstruction::GetLeakCntPV() const {
-    return fLeakCntPV;
 }
 
 inline const G4VPhysicalVolume* DRTB23SimDetectorConstruction::GetWorldPV() const {

--- a/include/DRTB23SimEventAction.hh
+++ b/include/DRTB23SimEventAction.hh
@@ -36,7 +36,6 @@ class DRTB23SimEventAction : public G4UserEventAction {
     
         void AddScin(G4double de);//Add energy in scintillating fibers
         void AddCher(G4double de);//Add energy in Cherenkov fibers
-        void Addenergy(G4double de);//Add energy depositedin calo
         void SavePrimaryPDGID(G4int pdgid);
         void SavePrimaryXY(G4double x, G4double y);
         void SaveAbsorberMaterial(G4String AbsorberMaterialName);
@@ -145,10 +144,6 @@ inline void DRTB23SimEventAction::AddScin(G4double de){
 
 inline void DRTB23SimEventAction::AddCher(G4double de){
     EnergyCher += de;
-}
-
-inline void DRTB23SimEventAction::Addenergy(G4double de){
-    EnergyTot += de;
 }
 
 inline void DRTB23SimEventAction::AddPSEnergy(G4double de){

--- a/include/DRTB23SimSignalHelper.hh
+++ b/include/DRTB23SimSignalHelper.hh
@@ -22,10 +22,10 @@ class DRTB23SimSignalHelper {
 
         static DRTB23SimSignalHelper* instance;
 
-		const G4double fk_B = 0.126; //Birks constant
+	const G4double fk_B = 0.126; //Birks constant
 
-		const G4double fSAttenuationLength = 191.6*CLHEP::cm; // from test beam data
-		const G4double fCAttenuationLength = 388.9*CLHEP::cm; // from test beam data
+	const G4double fSAttenuationLength = 191.6*CLHEP::cm; // from test beam data
+	const G4double fCAttenuationLength = 388.9*CLHEP::cm; // from test beam data
 
 	//Private constructor (singleton)
         //
@@ -37,17 +37,18 @@ class DRTB23SimSignalHelper {
 
     	G4double ApplyBirks( const G4double& de, const G4double& steplength );
 
-	    G4int SmearSSignal( const G4double& de );
+	G4int SmearSSignal( const G4double& de );
 
     	G4int SmearCSignal( );
 
-		G4double GetDistanceToSiPM(const G4Step* step);
+    	G4double GetDistanceToSiPM(const G4Step* step);
 
-		G4int AttenuateHelper(const G4int& signal, const G4double& distance, const G4double& attenuation_length);
+	G4int AttenuateHelper(const G4int& signal, const G4double& distance, const G4double& attenuation_length);
 
-		G4int AttenuateSSignal(const G4int& signal, const G4double& distance);
+	G4int AttenuateSSignal(const G4int& signal, const G4double& distance);
 
-		G4int AttenuateCSignal(const G4int& signal, const G4double& distance);
+	G4int AttenuateCSignal(const G4int& signal, const G4double& distance);
+
 };
 
 #endif

--- a/include/DRTB23SimSteppingAction.hh
+++ b/include/DRTB23SimSteppingAction.hh
@@ -59,7 +59,7 @@ class DRTB23SimSteppingAction : public G4UserSteppingAction {
 
         G4OpBoundaryProcess* fOpProcess;
                 
-	//Pointer to DRTB23SimDetectorConstruction
+	//Pointers
 	//
         const DRTB23SimDetectorConstruction* fDetConstruction;
 	G4VPhysicalVolume* fWorldPV; //PV: world volume

--- a/include/DRTB23SimSteppingAction.hh
+++ b/include/DRTB23SimSteppingAction.hh
@@ -15,6 +15,7 @@
 //
 #include "G4UserSteppingAction.hh"
 #include "G4Types.hh"
+#include "G4LogicalVolume.hh"
 
 //Forward declarations from Geant4
 //
@@ -61,6 +62,15 @@ class DRTB23SimSteppingAction : public G4UserSteppingAction {
 	//Pointer to DRTB23SimDetectorConstruction
 	//
         const DRTB23SimDetectorConstruction* fDetConstruction;
+	G4VPhysicalVolume* fWorldPV; //PV: world volume
+        G4VPhysicalVolume* fPSPV; //PV: preshower volume
+        G4VPhysicalVolume* fPSScinPV; //PV: preshower scintillator volume
+        G4LogicalVolume*   fSfiber_Abs_LV; //LV: Absorber of S fiber
+        G4LogicalVolume*   fSfiber_Core_LV; //LV: Core of S fiber
+        G4LogicalVolume*   fSfiber_Clad_LV; //LV: Cladding of S fiber
+        G4LogicalVolume*   fCfiber_Abs_LV; //LV: Absorber of C fiber
+        G4LogicalVolume*   fCfiber_Core_LV; //LV: Core of C fiber
+        G4LogicalVolume*   fCfiber_Clad_LV; //LV: Cladding of C fiber
 				
         //Pointer to only existing implementation (singleton)
     	//of DRTB23SimTowerHelper

--- a/include/DRTB23SimSteppingAction.hh
+++ b/include/DRTB23SimSteppingAction.hh
@@ -35,8 +35,7 @@ class DRTB23SimSteppingAction : public G4UserSteppingAction {
     public:
         //Constructor
         //
-        DRTB23SimSteppingAction(DRTB23SimEventAction* eventAction,
-				const DRTB23SimDetectorConstruction* detConstruction );
+        DRTB23SimSteppingAction(DRTB23SimEventAction* eventAction);
         //De-constructor
         //
         virtual ~DRTB23SimSteppingAction();
@@ -61,7 +60,6 @@ class DRTB23SimSteppingAction : public G4UserSteppingAction {
                 
 	//Pointers
 	//
-        const DRTB23SimDetectorConstruction* fDetConstruction;
 	G4VPhysicalVolume* fWorldPV; //PV: world volume
         G4VPhysicalVolume* fPSPV; //PV: preshower volume
         G4VPhysicalVolume* fPSScinPV; //PV: preshower scintillator volume

--- a/src/DRTB23SimActionInitialization.cc
+++ b/src/DRTB23SimActionInitialization.cc
@@ -15,9 +15,8 @@
 
 //Constructor
 //
-DRTB23SimActionInitialization::DRTB23SimActionInitialization( DRTB23SimDetectorConstruction* detConstruction )
-    : G4VUserActionInitialization(),
-    fDetConstruction( detConstruction )		
+DRTB23SimActionInitialization::DRTB23SimActionInitialization()
+    : G4VUserActionInitialization()
 {}
 
 //De-constructor
@@ -41,7 +40,7 @@ void DRTB23SimActionInitialization::Build() const {
     SetUserAction(new DRTB23SimRunAction( eventAction ));
     SetUserAction(new DRTB23SimPrimaryGeneratorAction(eventAction) );
     SetUserAction(eventAction);
-    SetUserAction(new DRTB23SimSteppingAction(eventAction, fDetConstruction));
+    SetUserAction(new DRTB23SimSteppingAction(eventAction));
 
 }  
 

--- a/src/DRTB23SimDetectorConstruction.cc
+++ b/src/DRTB23SimDetectorConstruction.cc
@@ -123,7 +123,6 @@ const G4double sq3m1=sq3/3.;
 DRTB23SimDetectorConstruction::DRTB23SimDetectorConstruction()
     : G4VUserDetectorConstruction(),
     fCheckOverlaps(false),
-    fLeakCntPV(nullptr),
     fWorldPV(nullptr){
 
     fGeoMessenger = new DRTB23SimGeoMessenger(this);
@@ -534,25 +533,6 @@ G4VPhysicalVolume* DRTB23SimDetectorConstruction::DefineVolumes() {
     PSScinVisAtt->SetVisibility(true);
     PSScinLV->SetVisAttributes( PSScinVisAtt );
  
-    //Absorber to calculate leakage
-    //
-    G4VSolid* leakageabsorber = new G4Sphere("leakageabsorber",                        
-        7.*m, 7.1*m, 0.*deg, 360.*deg, 0.*deg, 180.*deg); 
-    
-    G4LogicalVolume* leakageabsorberLV = new G4LogicalVolume(leakageabsorber,
-                                                             defaultMaterial,  
-                                                             "leakageabsorber");        
-    
-    leakageabsorberLV->SetVisAttributes(G4VisAttributes::Invisible);   
-
-    fLeakCntPV = new G4PVPlacement( 0, G4ThreeVector(),
-				    leakageabsorberLV,         
-                                    "leakageabsorber",
-                                    worldLV,               
-                                    false,          
-                                    0,               
-                                    fCheckOverlaps);
-
    // Module equipped
    //
    // Basic module structure: extrusion of an hexcell shape

--- a/src/DRTB23SimDetectorConstruction.cc
+++ b/src/DRTB23SimDetectorConstruction.cc
@@ -874,8 +874,7 @@ G4VPhysicalVolume* DRTB23SimDetectorConstruction::DefineVolumes() {
                 vec_S_fiber.setZ(0.);
 
                 copynumber = ((NofFibersrow/2)*column+row/2);
-                auto logic_S_fiber = constructscinfiber(tolerance,
-                                                        tuberadius,
+                auto logic_S_fiber = constructscinfiber(tuberadius,
                                                         fiberZ,
                                                         absorberMaterial,
                                                         coreradius,
@@ -927,8 +926,7 @@ G4VPhysicalVolume* DRTB23SimDetectorConstruction::DefineVolumes() {
 
                 copynumber = ((NofFibersrow/2)*column+row/2);
                         
-                auto logic_C_fiber = constructcherfiber(tolerance,
-                                                        tuberadius,
+                auto logic_C_fiber = constructcherfiber(tuberadius,
                                                         fiberZ,
                                                         absorberMaterial,
                                                         coreradius,
@@ -957,41 +955,26 @@ G4VPhysicalVolume* DRTB23SimDetectorConstruction::DefineVolumes() {
 
 // Define constructscinfiber method()
 //
-G4LogicalVolume* DRTB23SimDetectorConstruction::constructscinfiber(double tolerance,
-    G4double tuberadius, G4double fiberZ, G4Material* absorberMaterial, 
+G4LogicalVolume* DRTB23SimDetectorConstruction::constructscinfiber(G4double tuberadius,
+    G4double fiberZ, G4Material* absorberMaterial, 
     G4double coreradius, G4double coreZ, G4Material* ScinMaterial, 
     G4double claddingradiusmin, G4double claddingradiusmax, G4double claddingZ,
     G4Material* CherMaterial){
   
-    std::random_device rd;  //Will be used to obtain a seed for the random number engine
-    std::mt19937 gen(rd()); //Standard mersenne_twister_engine seeded with rd()m
-    std::uniform_real_distribution<> dis(0.0, tolerance);
-    double outradiussmear = dis(gen);
-    tuberadius = tuberadius+outradiussmear;
-  
-    // Tube for scintillating fibers
-    //
+    //Tube
     G4Tubs* S_fiber = new G4Tubs("S_fiber", 0., tuberadius, fiberZ/2, 0., 2.*pi);
 
     G4LogicalVolume* logic_S_fiber = new G4LogicalVolume(S_fiber,
                                                          absorberMaterial,
                                                          "S_fiber");
-//    logic_S_fiber->SetVisAttributes(G4VisAttributes::Invisible);
-	
-    G4Tubs* Abs_S_fiber = new G4Tubs("Abs_Scin_fiber", claddingradiusmax, tuberadius, fiberZ/2,0.,2.*pi);
 
-    G4LogicalVolume* logic_Abs_S_fiber = new G4LogicalVolume(Abs_S_fiber,
-                                                             absorberMaterial,
-                                                             "Abs_Scin_fiber");
-    /*G4VPhysicalVolume* =*/ new G4PVPlacement(0,
-                                               G4ThreeVector(0.,0.,0.),
-                                               logic_Abs_S_fiber,
-                                               "Abs_Scin_fiber",
-                                               logic_S_fiber,
-                                               false,
-                                               0,
-                                               fCheckOverlaps);
+    G4VisAttributes* TubeVisAtt = new G4VisAttributes(G4Colour(0.6,0.3,0.3));
+    TubeVisAtt->SetVisibility(true);
+    TubeVisAtt->SetForceWireframe(true);
+    TubeVisAtt->SetForceSolid(true);
+    logic_S_fiber->SetVisAttributes(TubeVisAtt);
 
+    //Core
     G4Tubs* Core_S_fiber = new G4Tubs("Core_S_fiber", 0., 
                                       coreradius, coreZ/2, 0., 2.*pi);
 
@@ -999,41 +982,37 @@ G4LogicalVolume* DRTB23SimDetectorConstruction::constructscinfiber(double tolera
                                                               ScinMaterial,
                                                               "Core_S_fiber");
 
-    G4VisAttributes* ScincoreVisAtt = new G4VisAttributes(G4Colour(0.0,0.0,0.8)); //blue
+    G4VisAttributes* ScincoreVisAtt = new G4VisAttributes(G4Colour(0.0,0.0,0.8));
     ScincoreVisAtt->SetVisibility(true);
     ScincoreVisAtt->SetForceWireframe(true);
     ScincoreVisAtt->SetForceSolid(true);
     logic_Core_S_fiber->SetVisAttributes(ScincoreVisAtt);
-//    logic_Core_S_fiber->SetVisAttributes(G4VisAttributes::Invisible);
     G4ThreeVector vec_Core_S;
     vec_Core_S.setX(0.);
     vec_Core_S.setY(0.);
     vec_Core_S.setZ(0.); 
                              
     /*G4VPhysicalVolume* =*/ new G4PVPlacement(0,
-                                                     vec_Core_S,
-                                                     logic_Core_S_fiber,
-                                                     "Core_S_fiber",
-                                                     logic_S_fiber,
-                                                     false,
-                                                     0,
-                                                     fCheckOverlaps);
- 
+                                               vec_Core_S,
+                                               logic_Core_S_fiber,
+                                               "Core_S_fiber",
+                                               logic_S_fiber,
+                                               false,
+                                               0,
+                                               fCheckOverlaps);
 
-    G4Tubs* Clad_S_fiber = new G4Tubs("Clad_S_fiber", claddingradiusmin, 
-        claddingradiusmax, claddingZ/2, 0., 2.*pi);
+    //Cladding
+    G4Tubs* Clad_S_fiber = new G4Tubs("Clad_S_fiber", claddingradiusmin, claddingradiusmax, claddingZ/2, 0., 2.*pi);
 
     G4LogicalVolume* logic_Clad_S_fiber = new G4LogicalVolume(Clad_S_fiber,
                                                               CherMaterial,
                                                               "Clad_S_fiber");
 
     G4VisAttributes* ScincladVisAtt = new G4VisAttributes(G4Colour(0.0,1.0,1.0));
-    //light blue
     ScincladVisAtt->SetVisibility(true);
     ScincladVisAtt->SetForceWireframe(true);
     ScincladVisAtt->SetForceSolid(true);
     logic_Clad_S_fiber->SetVisAttributes(ScincladVisAtt);
-//    logic_Clad_S_fiber->SetVisAttributes(G4VisAttributes::Invisible);
 
     G4ThreeVector vec_Clad_S;
     vec_Clad_S.setX(0.);
@@ -1041,21 +1020,13 @@ G4LogicalVolume* DRTB23SimDetectorConstruction::constructscinfiber(double tolera
     vec_Clad_S.setZ(0.); 
                              
     /*G4VPhysicalVolume* =*/ new G4PVPlacement(0,
-                                                     vec_Clad_S,
-                                                     logic_Clad_S_fiber,
-                                                     "Clad_S_fiber",
-                                                      logic_S_fiber,
-                                                      false,
-                                                      0,
-                                                      fCheckOverlaps);
-
-
-    G4VisAttributes* TubeVisAtt = new G4VisAttributes(G4Colour(0.6,0.3,0.3)); //blue
-    TubeVisAtt->SetVisibility(true);
-    TubeVisAtt->SetForceWireframe(true);
-    TubeVisAtt->SetForceSolid(true);
-    logic_Abs_S_fiber->SetVisAttributes(TubeVisAtt);
-//    logic_Abs_S_fiber->SetVisAttributes(G4VisAttributes::Invisible);
+                                               vec_Clad_S,
+                                               logic_Clad_S_fiber,
+                                               "Clad_S_fiber",
+                                               logic_S_fiber,
+                                               false,
+                                               0,
+                                               fCheckOverlaps);
     
     return logic_S_fiber;
 
@@ -1063,105 +1034,81 @@ G4LogicalVolume* DRTB23SimDetectorConstruction::constructscinfiber(double tolera
 
 // Define constructcherfiber() method
 //
-G4LogicalVolume* DRTB23SimDetectorConstruction::constructcherfiber(double tolerance,
-    G4double tuberadius, G4double fiberZ, G4Material* absorberMaterial,
+G4LogicalVolume* DRTB23SimDetectorConstruction::constructcherfiber(G4double tuberadius,
+    G4double fiberZ, G4Material* absorberMaterial,
     G4double coreradius, G4double coreZ, G4Material* CherMaterial, 
     G4double claddingradiusmin, G4double claddingradiusmax, G4double claddingZ, 
     G4Material* CladCherMaterial){ 
  
-    std::random_device rd;  //Will be used to obtain a seed for the random number engine
-    std::mt19937 gen(rd()); //Standard mersenne_twister_engine seeded with rd()m
-    std::uniform_real_distribution<> dis(0.0, tolerance);
-    double outradiussmear = dis(gen);
-    tuberadius = tuberadius+outradiussmear;
-
+    //Tube
     G4Tubs* C_fiber = new G4Tubs("C_fiber", 0., tuberadius, fiberZ/2, 0., 2.*pi);
 
     G4LogicalVolume* logic_C_fiber = new G4LogicalVolume(C_fiber,
                                                          absorberMaterial,
                                                          "C_fiber");
 
-//    logic_C_fiber->SetVisAttributes(G4VisAttributes::Invisible);
-    G4Tubs* Abs_C_fiber = new G4Tubs("Abs_Cher_fiber", claddingradiusmax, tuberadius, fiberZ/2,0.,2.*pi);
+    G4VisAttributes* TubeVisAtt = new G4VisAttributes(G4Colour(0.6,0.3,0.3));
+    TubeVisAtt->SetVisibility(true);
+    TubeVisAtt->SetForceWireframe(true);
+    TubeVisAtt->SetForceSolid(true);
+    logic_C_fiber->SetVisAttributes(TubeVisAtt);
 
-    G4LogicalVolume* logic_Abs_C_fiber = new G4LogicalVolume(Abs_C_fiber,
-                                                             absorberMaterial,
-                                                             "Abs_Cher_fiber");
-    /*G4VPhysicalVolume* =*/ new G4PVPlacement(0,
-                                                     G4ThreeVector(0.,0.,0.),
-                                                     logic_Abs_C_fiber,
-                                                     "Abs_Cher_fiber",
-                                                     logic_C_fiber,
-                                                     false,
-                                                     0,
-                                                     fCheckOverlaps);
-
+    //Core
     G4Tubs* Core_C_fiber = new G4Tubs("Core_C_fiber", 0., coreradius, coreZ/2, 0., 2.*pi);
 
     G4LogicalVolume* logic_Core_C_fiber = new G4LogicalVolume(Core_C_fiber,
                                                               CherMaterial,
                                                               "Core_C_fiber");
 
-    G4VisAttributes* ChercoreVisAtt = new G4VisAttributes(G4Colour(1.0,0.0,0.0)); //red
+    G4VisAttributes* ChercoreVisAtt = new G4VisAttributes(G4Colour(1.0,0.0,0.0));
     ChercoreVisAtt->SetVisibility(true);
     ChercoreVisAtt->SetForceWireframe(true);
     ChercoreVisAtt->SetForceSolid(true);
     logic_Core_C_fiber->SetVisAttributes(ChercoreVisAtt);
-//    logic_Core_C_fiber->SetVisAttributes(G4VisAttributes::Invisible);
     G4ThreeVector vec_Core_C;
     vec_Core_C.setX(0.);
     vec_Core_C.setY(0.);
     vec_Core_C.setZ(0.); 
                              
     /*G4VPhysicalVolume* =*/ new G4PVPlacement(0,
-                                                    vec_Core_C,
-                                                    logic_Core_C_fiber,
-                                                    "Core_C_fiber",
-                                                    logic_C_fiber,
-                                                    false,
-                                                    0,
-                                                    fCheckOverlaps);
+                                               vec_Core_C,
+                                               logic_Core_C_fiber,
+                                               "Core_C_fiber",
+                                               logic_C_fiber,
+                                               false,
+                                               0,
+                                               fCheckOverlaps);
 
-    G4Tubs* Clad_C_fiber = new G4Tubs("Clad_C_fiber", claddingradiusmin,
-        claddingradiusmax, claddingZ/2, 0., 2.*pi);
+    //Cladding
+    G4Tubs* Clad_C_fiber = new G4Tubs("Clad_C_fiber", claddingradiusmin, claddingradiusmax, claddingZ/2, 0., 2.*pi);
 
     G4LogicalVolume* logic_Clad_C_fiber = new G4LogicalVolume(Clad_C_fiber,
                                                               CladCherMaterial,
                                                               "Clad_C_fiber");
 
     G4VisAttributes* ChercladVisAtt = new G4VisAttributes(G4Colour(1.0,1.0,0.0));
-    //yellow 
     ChercladVisAtt->SetVisibility(true);
     ChercladVisAtt->SetForceWireframe(true);
     ChercladVisAtt->SetForceSolid(true);
     logic_Clad_C_fiber->SetVisAttributes(ChercladVisAtt);
-//    logic_Clad_C_fiber->SetVisAttributes(G4VisAttributes::Invisible);
-
     G4ThreeVector vec_Clad_C;
     vec_Clad_C.setX(0.);
     vec_Clad_C.setY(0.);
     vec_Clad_C.setZ(0.); 
                              
     /*G4VPhysicalVolume* =*/ new G4PVPlacement(0,
-                                                     vec_Clad_C,
-                                                     logic_Clad_C_fiber,
-                                                     "Clad_C_fiber",
-                                                     logic_C_fiber,
-                                                     false,
-                                                     0,
-                                                     fCheckOverlaps);
-
-    G4VisAttributes* TubeVisAtt = new G4VisAttributes(G4Colour(0.6,0.3,0.3)); //blue
-    TubeVisAtt->SetVisibility(true);
-    TubeVisAtt->SetForceWireframe(true);
-    TubeVisAtt->SetForceSolid(true);
-    logic_Abs_C_fiber->SetVisAttributes(TubeVisAtt);
-//    logic_Abs_C_fiber->SetVisAttributes(G4VisAttributes::Invisible);
+                                               vec_Clad_C,
+                                               logic_Clad_C_fiber,
+                                               "Clad_C_fiber",
+                                               logic_C_fiber,
+                                               false,
+                                               0,
+                                               fCheckOverlaps);
 
     return logic_C_fiber;
 
 }
-//
+
 //   method to define polygonal contour of module to extrude
 //
 std::vector<G4TwoVector> DRTB23SimDetectorConstruction::calcmod(double radius, int nrow, int ncol) {
@@ -1203,3 +1150,5 @@ std::vector<G4TwoVector> DRTB23SimDetectorConstruction::calcmod(double radius, i
    }
    return polygon1;
 }
+
+//**************************************************

--- a/src/DRTB23SimDetectorConstruction.cc
+++ b/src/DRTB23SimDetectorConstruction.cc
@@ -123,7 +123,9 @@ const G4double sq3m1=sq3/3.;
 DRTB23SimDetectorConstruction::DRTB23SimDetectorConstruction()
     : G4VUserDetectorConstruction(),
     fCheckOverlaps(false),
-    fWorldPV(nullptr){
+    fWorldPV(nullptr),
+    fPSPV(nullptr),
+    fPSScinPV(nullptr){
 
     fGeoMessenger = new DRTB23SimGeoMessenger(this);
 }

--- a/src/DRTB23SimDetectorConstruction.cc
+++ b/src/DRTB23SimDetectorConstruction.cc
@@ -125,7 +125,13 @@ DRTB23SimDetectorConstruction::DRTB23SimDetectorConstruction()
     fCheckOverlaps(false),
     fWorldPV(nullptr),
     fPSPV(nullptr),
-    fPSScinPV(nullptr){
+    fPSScinPV(nullptr),
+    fSfiber_Abs_LV(nullptr),
+    fSfiber_Core_LV(nullptr),
+    fSfiber_Clad_LV(nullptr),
+    fCfiber_Abs_LV(nullptr),
+    fCfiber_Core_LV(nullptr),
+    fCfiber_Clad_LV(nullptr){
 
     fGeoMessenger = new DRTB23SimGeoMessenger(this);
 }
@@ -848,6 +854,17 @@ G4VPhysicalVolume* DRTB23SimDetectorConstruction::DefineVolumes() {
     //
     G4int copynumber = 0;
 
+    fSfiber_Abs_LV  = constructscinfiber(tuberadius,
+                                         fiberZ,
+                                         absorberMaterial,
+                                         coreradius,
+                                         coreZ,
+                                         ScinMaterial,
+                                         claddingradiusmin,
+                                         claddingradiusmax,
+                                         claddingZ,
+                                         CherMaterial);
+
     for(int column=0; column<NofFiberscolumn; column++){
         
         std::stringstream S_fiber_column;
@@ -874,21 +891,11 @@ G4VPhysicalVolume* DRTB23SimDetectorConstruction::DefineVolumes() {
                 vec_S_fiber.setZ(0.);
 
                 copynumber = ((NofFibersrow/2)*column+row/2);
-                auto logic_S_fiber = constructscinfiber(tuberadius,
-                                                        fiberZ,
-                                                        absorberMaterial,
-                                                        coreradius,
-                                                        coreZ,
-                                                        ScinMaterial,
-                                                        claddingradiusmin,
-                                                        claddingradiusmax,
-                                                        claddingZ,
-                                                        CherMaterial);
                 // Tubes with scintillating fiber placement
                 //
                 /*physi_S_fiber[column][row] =*/ new G4PVPlacement(0,
                                                                vec_S_fiber,
-                                                               logic_S_fiber,
+                                                               fSfiber_Abs_LV,
                                                                S_name,
                                                                moduleLV,
                                                                false,
@@ -897,9 +904,18 @@ G4VPhysicalVolume* DRTB23SimDetectorConstruction::DefineVolumes() {
         };
     };
 
+    fCfiber_Abs_LV = constructcherfiber(tuberadius,
+                                        fiberZ,
+                                        absorberMaterial,
+                                        coreradius,
+                                        coreZ,
+                                        CherMaterial,
+                                        claddingradiusmin,
+                                        claddingradiusmax,
+                                        claddingZ,
+                                        CladCherMaterial);
     // Tubes with Cherenkov fibers
     //
-  
     for(int column=0; column<NofFiberscolumn; column++){
         
         std::stringstream C_fiber_column;
@@ -925,20 +941,11 @@ G4VPhysicalVolume* DRTB23SimDetectorConstruction::DefineVolumes() {
                 vec_C_fiber.setZ(0.);
 
                 copynumber = ((NofFibersrow/2)*column+row/2);
-                        
-                auto logic_C_fiber = constructcherfiber(tuberadius,
-                                                        fiberZ,
-                                                        absorberMaterial,
-                                                        coreradius,
-                                                        coreZ,
-                                                        CherMaterial,
-                                                        claddingradiusmin,
-                                                        claddingradiusmax,
-                                                        claddingZ,
-                                                        CladCherMaterial);
+                // Tubes with scintillating fiber placement
+                //
                 /*physi_C_fiber[column][row] =*/ new G4PVPlacement(0,
                                                          vec_C_fiber,
-                                                         logic_C_fiber,
+                                                         fCfiber_Abs_LV,
                                                          C_name,
                                                          moduleLV,
                                                          false,
@@ -978,15 +985,13 @@ G4LogicalVolume* DRTB23SimDetectorConstruction::constructscinfiber(G4double tube
     G4Tubs* Core_S_fiber = new G4Tubs("Core_S_fiber", 0., 
                                       coreradius, coreZ/2, 0., 2.*pi);
 
-    G4LogicalVolume* logic_Core_S_fiber = new G4LogicalVolume(Core_S_fiber,
-                                                              ScinMaterial,
-                                                              "Core_S_fiber");
+    fSfiber_Core_LV = new G4LogicalVolume(Core_S_fiber,ScinMaterial,"Core_S_fiber");
 
     G4VisAttributes* ScincoreVisAtt = new G4VisAttributes(G4Colour(0.0,0.0,0.8));
     ScincoreVisAtt->SetVisibility(true);
     ScincoreVisAtt->SetForceWireframe(true);
     ScincoreVisAtt->SetForceSolid(true);
-    logic_Core_S_fiber->SetVisAttributes(ScincoreVisAtt);
+    fSfiber_Core_LV->SetVisAttributes(ScincoreVisAtt);
     G4ThreeVector vec_Core_S;
     vec_Core_S.setX(0.);
     vec_Core_S.setY(0.);
@@ -994,7 +999,7 @@ G4LogicalVolume* DRTB23SimDetectorConstruction::constructscinfiber(G4double tube
                              
     /*G4VPhysicalVolume* =*/ new G4PVPlacement(0,
                                                vec_Core_S,
-                                               logic_Core_S_fiber,
+                                               fSfiber_Core_LV,
                                                "Core_S_fiber",
                                                logic_S_fiber,
                                                false,
@@ -1004,15 +1009,13 @@ G4LogicalVolume* DRTB23SimDetectorConstruction::constructscinfiber(G4double tube
     //Cladding
     G4Tubs* Clad_S_fiber = new G4Tubs("Clad_S_fiber", claddingradiusmin, claddingradiusmax, claddingZ/2, 0., 2.*pi);
 
-    G4LogicalVolume* logic_Clad_S_fiber = new G4LogicalVolume(Clad_S_fiber,
-                                                              CherMaterial,
-                                                              "Clad_S_fiber");
+    fSfiber_Clad_LV = new G4LogicalVolume(Clad_S_fiber,CherMaterial,"Clad_S_fiber");
 
     G4VisAttributes* ScincladVisAtt = new G4VisAttributes(G4Colour(0.0,1.0,1.0));
     ScincladVisAtt->SetVisibility(true);
     ScincladVisAtt->SetForceWireframe(true);
     ScincladVisAtt->SetForceSolid(true);
-    logic_Clad_S_fiber->SetVisAttributes(ScincladVisAtt);
+    fSfiber_Clad_LV->SetVisAttributes(ScincladVisAtt);
 
     G4ThreeVector vec_Clad_S;
     vec_Clad_S.setX(0.);
@@ -1021,7 +1024,7 @@ G4LogicalVolume* DRTB23SimDetectorConstruction::constructscinfiber(G4double tube
                              
     /*G4VPhysicalVolume* =*/ new G4PVPlacement(0,
                                                vec_Clad_S,
-                                               logic_Clad_S_fiber,
+                                               fSfiber_Clad_LV,
                                                "Clad_S_fiber",
                                                logic_S_fiber,
                                                false,
@@ -1056,15 +1059,13 @@ G4LogicalVolume* DRTB23SimDetectorConstruction::constructcherfiber(G4double tube
     //Core
     G4Tubs* Core_C_fiber = new G4Tubs("Core_C_fiber", 0., coreradius, coreZ/2, 0., 2.*pi);
 
-    G4LogicalVolume* logic_Core_C_fiber = new G4LogicalVolume(Core_C_fiber,
-                                                              CherMaterial,
-                                                              "Core_C_fiber");
+    fCfiber_Core_LV = new G4LogicalVolume(Core_C_fiber,CherMaterial,"Core_C_fiber");
 
     G4VisAttributes* ChercoreVisAtt = new G4VisAttributes(G4Colour(1.0,0.0,0.0));
     ChercoreVisAtt->SetVisibility(true);
     ChercoreVisAtt->SetForceWireframe(true);
     ChercoreVisAtt->SetForceSolid(true);
-    logic_Core_C_fiber->SetVisAttributes(ChercoreVisAtt);
+    fCfiber_Core_LV->SetVisAttributes(ChercoreVisAtt);
     G4ThreeVector vec_Core_C;
     vec_Core_C.setX(0.);
     vec_Core_C.setY(0.);
@@ -1072,7 +1073,7 @@ G4LogicalVolume* DRTB23SimDetectorConstruction::constructcherfiber(G4double tube
                              
     /*G4VPhysicalVolume* =*/ new G4PVPlacement(0,
                                                vec_Core_C,
-                                               logic_Core_C_fiber,
+                                               fCfiber_Core_LV,
                                                "Core_C_fiber",
                                                logic_C_fiber,
                                                false,
@@ -1082,15 +1083,13 @@ G4LogicalVolume* DRTB23SimDetectorConstruction::constructcherfiber(G4double tube
     //Cladding
     G4Tubs* Clad_C_fiber = new G4Tubs("Clad_C_fiber", claddingradiusmin, claddingradiusmax, claddingZ/2, 0., 2.*pi);
 
-    G4LogicalVolume* logic_Clad_C_fiber = new G4LogicalVolume(Clad_C_fiber,
-                                                              CladCherMaterial,
-                                                              "Clad_C_fiber");
+    fCfiber_Clad_LV = new G4LogicalVolume(Clad_C_fiber,CladCherMaterial,"Clad_C_fiber");
 
     G4VisAttributes* ChercladVisAtt = new G4VisAttributes(G4Colour(1.0,1.0,0.0));
     ChercladVisAtt->SetVisibility(true);
     ChercladVisAtt->SetForceWireframe(true);
     ChercladVisAtt->SetForceSolid(true);
-    logic_Clad_C_fiber->SetVisAttributes(ChercladVisAtt);
+    fCfiber_Clad_LV->SetVisAttributes(ChercladVisAtt);
     G4ThreeVector vec_Clad_C;
     vec_Clad_C.setX(0.);
     vec_Clad_C.setY(0.);
@@ -1098,7 +1097,7 @@ G4LogicalVolume* DRTB23SimDetectorConstruction::constructcherfiber(G4double tube
                              
     /*G4VPhysicalVolume* =*/ new G4PVPlacement(0,
                                                vec_Clad_C,
-                                               logic_Clad_C_fiber,
+                                               fCfiber_Clad_LV,
                                                "Clad_C_fiber",
                                                logic_C_fiber,
                                                false,

--- a/src/DRTB23SimDetectorConstruction.cc
+++ b/src/DRTB23SimDetectorConstruction.cc
@@ -489,47 +489,34 @@ G4VPhysicalVolume* DRTB23SimDetectorConstruction::DefineVolumes() {
     //
     auto PSSolid = new G4Box("Preshower", PSX/2., PSY/2., PSZ/2.);
 
-    auto PSLV = new G4LogicalVolume(PSSolid, defaultMaterial, "Preshower");
+    auto PSLV = new G4LogicalVolume(PSSolid, LeadMaterial, "Preshower");
 
-    new G4PVPlacement( 0, 
-		       G4ThreeVector(preshower_pos_x, preshower_pos_y, preshower_pos_z - PSZ/2.),
-		       PSLV,
-		       "Preshower",
-		       stage_logical,
-		       false,
-		       0,
-		       fCheckOverlaps);	 
-
-    auto PSLeadSolid = new G4Box("Preshower_pb", PSX/2., PSY/2., PSZ/4.);
-
-    auto PSLeadLV = new G4LogicalVolume(PSLeadSolid, LeadMaterial, "Preshower_pb");
-
-    new G4PVPlacement( 0, 
-		       G4ThreeVector(0.,0.,-PSZ/4.),
-		       PSLeadLV,
-		       "Preshower_pb",
-		       PSLV,
-		       false,
-		       0,
-		       fCheckOverlaps);	 
+    fPSPV = new G4PVPlacement( 0, 
+		               G4ThreeVector(preshower_pos_x, preshower_pos_y, preshower_pos_z - PSZ/2.),
+		               PSLV,
+		               "Preshower",
+		               stage_logical,
+		               false,
+		               0,
+		               fCheckOverlaps); 
 
     G4VisAttributes* PbVisAtt = new G4VisAttributes( G4Colour::Grey() );
     PbVisAtt->SetVisibility(true);
     PbVisAtt->SetForceSolid(true);
-    PSLeadLV->SetVisAttributes( PbVisAtt );
+    PSLV->SetVisAttributes( PbVisAtt );
 
     auto PSScinSolid = new G4Box("Preshower_scin", PSX/2., PSY/2., PSZ/4.);
 
     auto PSScinLV = new G4LogicalVolume(PSScinSolid, PSScinMaterial, "Preshower_scin");
 
-    new G4PVPlacement( 0, 
-		       G4ThreeVector(0.,0.,PSZ/4.),
-                       PSScinLV,
-	               "Preshower_scin",
-                       PSLV,
-                       false,	
-                       0,
-                       fCheckOverlaps);	 
+    fPSScinPV = new G4PVPlacement( 0, 
+		                   G4ThreeVector(0.,0.,PSZ/4.),
+                                   PSScinLV,
+	                           "Preshower_scin",
+                                   PSLV,
+                                   false,
+                                   0,
+                                   fCheckOverlaps); 
 
     G4VisAttributes* PSScinVisAtt = new G4VisAttributes( G4Colour::Cyan() );
     PSScinVisAtt->SetVisibility(true);

--- a/src/DRTB23SimDetectorConstruction.cc
+++ b/src/DRTB23SimDetectorConstruction.cc
@@ -502,7 +502,7 @@ G4VPhysicalVolume* DRTB23SimDetectorConstruction::DefineVolumes() {
 
     G4VisAttributes* PbVisAtt = new G4VisAttributes( G4Colour::Grey() );
     PbVisAtt->SetVisibility(true);
-    PbVisAtt->SetForceSolid(true);
+    //PbVisAtt->SetForceSolid(true);
     PSLV->SetVisAttributes( PbVisAtt );
 
     auto PSScinSolid = new G4Box("Preshower_scin", PSX/2., PSY/2., PSZ/4.);
@@ -520,6 +520,7 @@ G4VPhysicalVolume* DRTB23SimDetectorConstruction::DefineVolumes() {
 
     G4VisAttributes* PSScinVisAtt = new G4VisAttributes( G4Colour::Cyan() );
     PSScinVisAtt->SetVisibility(true);
+    PSScinVisAtt->SetForceSolid(true);
     PSScinLV->SetVisAttributes( PSScinVisAtt );
  
    // Module equipped

--- a/src/DRTB23SimEventAction.cc
+++ b/src/DRTB23SimEventAction.cc
@@ -108,7 +108,7 @@ void DRTB23SimEventAction::EndOfEventAction(const G4Event* ) {
     analysisManager->FillNtupleDColumn(7, EscapedEnergy);
     analysisManager->FillNtupleDColumn(8, PSEnergy);
     analysisManager->FillNtupleDColumn(9, PSSciEnergy);
-    analysisManager->FillNtupleDColumn(10, PrimaryX);
+    analysisManager->FillNtupleDColumn(10,PrimaryX);
     analysisManager->FillNtupleDColumn(11,PrimaryY);
     analysisManager->AddNtupleRow();
     //Vector entries in ntuple are automatically filled

--- a/src/DRTB23SimEventAction.cc
+++ b/src/DRTB23SimEventAction.cc
@@ -24,6 +24,7 @@
 //
 #include <iomanip>
 #include <vector>
+#include <numeric>
 
 //Define constructor
 //
@@ -94,6 +95,10 @@ void DRTB23SimEventAction::EndOfEventAction(const G4Event* ) {
     for (auto& n : VecSPMT) NofScinDet += n;
     for (auto& n : VectorSignalsCher) NofCherDet += n;
     for (auto& n : VecCPMT) NofCherDet += n;
+
+    //Add to EnergyTot the energies in towers
+    //
+    EnergyTot = std::accumulate(VecTowerE.begin(),VecTowerE.end(),0.);
 
     //Fill ntuple event by event
     //entries with vectors are automatically filled

--- a/src/DRTB23SimEventAction.cc
+++ b/src/DRTB23SimEventAction.cc
@@ -89,12 +89,10 @@ void DRTB23SimEventAction::EndOfEventAction(const G4Event* ) {
  
     G4AnalysisManager* analysisManager = G4AnalysisManager::Instance();
 
-    //Add all p.e. in Scin and Cher fibers before calibration
+    //Add all p.e. in Scin and Cher fibers
     //
-    for (auto& n : VectorSignals) NofScinDet += n;
-    for (auto& n : VecSPMT) NofScinDet += n;
-    for (auto& n : VectorSignalsCher) NofCherDet += n;
-    for (auto& n : VecCPMT) NofCherDet += n;
+    NofScinDet = std::accumulate(VecSPMT.begin(),VecSPMT.end(),0);
+    NofCherDet = std::accumulate(VecCPMT.begin(),VecCPMT.end(),0);
 
     //Add to EnergyTot the energies in towers
     //

--- a/src/DRTB23SimEventAction.cc
+++ b/src/DRTB23SimEventAction.cc
@@ -115,6 +115,8 @@ void DRTB23SimEventAction::EndOfEventAction(const G4Event* ) {
     analysisManager->FillNtupleDColumn(9, PSSciEnergy);
     analysisManager->FillNtupleDColumn(10,PrimaryX);
     analysisManager->FillNtupleDColumn(11,PrimaryY);
+    analysisManager->FillNtupleDColumn(12,std::accumulate(VectorSignals.begin(),VectorSignals.end(),0.));
+    analysisManager->FillNtupleDColumn(13,std::accumulate(VectorSignalsCher.begin(),VectorSignalsCher.end(),0.));
     analysisManager->AddNtupleRow();
     //Vector entries in ntuple are automatically filled
 

--- a/src/DRTB23SimRunAction.cc
+++ b/src/DRTB23SimRunAction.cc
@@ -59,6 +59,8 @@ DRTB23SimRunAction::DRTB23SimRunAction( DRTB23SimEventAction* eventAction )
     analysisManager->CreateNtupleDColumn("PSSciEnergy");                    //9
     analysisManager->CreateNtupleDColumn("PrimaryX");                       //10
     analysisManager->CreateNtupleDColumn("PrimaryY");                       //11
+    analysisManager->CreateNtupleDColumn("NofSiPMScinDet");                 //12
+    analysisManager->CreateNtupleDColumn("NofSiPMCherDet");                 //13
     analysisManager->CreateNtupleDColumn("VectorSignals", fEventAction->GetVectorSignals());
     analysisManager->CreateNtupleDColumn("VectorSignalsCher", fEventAction->GetVectorSignalsCher());
     analysisManager->CreateNtupleDColumn("VecTowerE", fEventAction->GetVecTowerE());

--- a/src/DRTB23SimSignalHelper.cc
+++ b/src/DRTB23SimSignalHelper.cc
@@ -45,19 +45,11 @@ G4double DRTB23SimSignalHelper::ApplyBirks( const G4double& de, const G4double& 
 
 //Define SmearSSignal() method
 //
-G4int DRTB23SimSignalHelper::SmearSSignal( const G4double& satde ) {
-		
-    return G4Poisson(satde*9.5);
-		
-}
+G4int DRTB23SimSignalHelper::SmearSSignal( const G4double& satde ) { return G4Poisson(satde*21.32); }
 
 //Define SmearCSignal() method
 //
-G4int DRTB23SimSignalHelper::SmearCSignal( ){
-		
-    return G4Poisson(0.153);
-
-}
+G4int DRTB23SimSignalHelper::SmearCSignal( ){ return G4Poisson(0.243); }
 
 //Define GetDistanceToSiPM() method
 //

--- a/src/DRTB23SimSteppingAction.cc
+++ b/src/DRTB23SimSteppingAction.cc
@@ -24,11 +24,9 @@
 
 //Define constructor
 //
-DRTB23SimSteppingAction::DRTB23SimSteppingAction( DRTB23SimEventAction* eventAction,
-						  const DRTB23SimDetectorConstruction* detConstruction )
+DRTB23SimSteppingAction::DRTB23SimSteppingAction( DRTB23SimEventAction* eventAction )
     : G4UserSteppingAction(),
     fEventAction(eventAction),
-    fDetConstruction(detConstruction),
     fWorldPV(nullptr),
     fPSPV(nullptr),
     fPSScinPV(nullptr),
@@ -98,7 +96,10 @@ void DRTB23SimSteppingAction::AuxSteppingAction( const G4Step* step ) {
 
     if ( Lvolume== fSfiber_Clad_LV || Lvolume== fSfiber_Core_LV || Lvolume== fSfiber_Abs_LV  ||
          Lvolume== fCfiber_Clad_LV || Lvolume== fCfiber_Core_LV || Lvolume== fCfiber_Abs_LV ) {
-        fEventAction->AddVecTowerE(fDetConstruction->GetTowerID(step->GetPreStepPoint()->GetTouchableHandle()->GetCopyNumber(3)), edep );
+        fEventAction->AddVecTowerE(step->GetPreStepPoint()->GetTouchableHandle()->GetCopyNumber(3), edep );
+        if (Lvolume==fSfiber_Core_LV) fEventAction->AddScin(edep);
+        else if (Lvolume==fCfiber_Core_LV) fEventAction->AddCher(edep);
+        else {}
     }
 
     //Collect energy in preshower (whole and scintillator)
@@ -108,68 +109,71 @@ void DRTB23SimSteppingAction::AuxSteppingAction( const G4Step* step ) {
     if ( volume == fPSScinPV ){
         fEventAction->AddPSSciEnergy( edep );
     }
-    
+ 
 }
 
 //Define FastSteppingAction() method
 //
 void DRTB23SimSteppingAction::FastSteppingAction( const G4Step* step ) { 
 		
+    //-----------------------------------------------------
+    //Store signals from Scintillation and Cherenkov fibers
+    //-----------------------------------------------------
+
+    //Get volumes of interest, i.e. core of fibers
+    //
+    if(!fWorldPV){
+        const DRTB23SimDetectorConstruction* detector = 
+            static_cast<const DRTB23SimDetectorConstruction*>(G4RunManager::GetRunManager()->GetUserDetectorConstruction());
+        fSfiber_Core_LV = detector->GetSCoreLV();
+        fCfiber_Core_LV = detector->GetCCoreLV();
+    }
+
     // Get step info
     //
-    G4VPhysicalVolume* volume 
-        = step->GetPreStepPoint()->GetTouchableHandle()->GetVolume();
+    G4LogicalVolume* Lvolume 
+        = step->GetPreStepPoint()->GetTouchableHandle()->GetVolume()->GetLogicalVolume();
     G4double edep = step->GetTotalEnergyDeposit();
     G4double steplength = step->GetStepLength();
-    
-    //--------------------------------------------------
-    //Store information from Scintillation and Cherenkov
-    //signals
-    //--------------------------------------------------
-   
-    std::string Fiber;
-    std::string S_fiber = "S_fiber";
-    std::string C_fiber = "C_fiber";
-    Fiber = volume->GetName(); 
-    G4int TowerID;
-    G4int SiPMID = 900;
-    G4int SiPMTower;
-    G4int signalhit = 0;
 
-    if ( strstr( Fiber.c_str(), S_fiber.c_str() ) ) { //scintillating fiber/tube
+    //Return if the step is not in core of fibers
+    //
+    if( Lvolume != fSfiber_Core_LV && Lvolume != fCfiber_Core_LV) return;
+
+    else if (Lvolume == fSfiber_Core_LV){ //scintillating fiber
+ 
+        G4int signalhit = 0;
 
         if ( step->GetTrack()->GetParticleDefinition() == G4OpticalPhoton::Definition() ) {
             step->GetTrack()->SetTrackStatus( fStopAndKill ); 
-	}
-
-	if ( step->GetTrack()->GetDefinition()->GetPDGCharge() == 0 || step->GetStepLength() == 0. ) { return; } //not ionizing particle
-//    G4VPhysicalVolume* modvolume 
-//        = step->GetPreStepPoint()->GetTouchableHandle()->GetVolume(3);
-//	 std::cout << " grandmother name " << modvolume->GetName() << " number " << modvolume->GetCopyNo() << std::endl;
-//        std::cout << " grandmother nunber " << step->GetPreStepPoint()->GetTouchableHandle()->GetCopyNumber(3) << std::endl;
-
-    G4double distance_to_sipm = fSignalHelper->GetDistanceToSiPM(step);
-
-	TowerID = fDetConstruction->GetTowerID(step->GetPreStepPoint()->GetTouchableHandle()->GetCopyNumber(3));
-	SiPMTower=fDetConstruction->GetSiPMTower(TowerID);
-	fEventAction->AddScin(edep);
-	signalhit = fSignalHelper->SmearSSignal( fSignalHelper->ApplyBirks( edep, steplength ) );
-    // Attenuate Signal
-    signalhit = fSignalHelper->AttenuateSSignal(signalhit, distance_to_sipm);
-//	if ( TowerID != 0 ) { fEventAction->AddVecSPMT( TowerID, signalhit ); }
-	fEventAction->AddVecSPMT( TowerID, signalhit ); 
-	if(SiPMTower > -1){ 
-            SiPMID = fDetConstruction->GetSiPMID(step->GetPreStepPoint()->GetTouchableHandle()->GetCopyNumber(1));
-	    fEventAction->AddVectorScin( signalhit, SiPMTower*NoFibersTower+SiPMID ); 
+            return;
         }
-    }
 
-    if ( strstr( Fiber.c_str(), C_fiber.c_str() ) ) { //Cherenkov fiber/tube
+	if ( step->GetTrack()->GetDefinition()->GetPDGCharge() == 0 || step->GetStepLength() == 0. 
+             || edep == 0. ) { return; }
 
-        fEventAction->AddCher(edep);
+        //G4VPhysicalVolume* modvolume 
+        //    = step->GetPreStepPoint()->GetTouchableHandle()->GetVolume(3);
+        //G4cout << " grandmother name " << modvolume->GetName() << " number " << modvolume->GetCopyNo() << G4endl;
+        //G4cout << " grandmother nunber " << step->GetPreStepPoint()->GetTouchableHandle()->GetCopyNumber(3) << G4endl;
+
+        G4double distance_to_sipm = fSignalHelper->GetDistanceToSiPM(step);
+
+        G4int TowerID = step->GetPreStepPoint()->GetTouchableHandle()->GetCopyNumber(3);
+	signalhit = fSignalHelper->SmearSSignal( fSignalHelper->ApplyBirks( edep, steplength ) );
+        // Attenuate Signal
+        signalhit = fSignalHelper->AttenuateSSignal(signalhit, distance_to_sipm);
+	fEventAction->AddVecSPMT( TowerID, signalhit ); 
+	if(TowerID == 0){ // in sipm-readout tower
+            G4int SiPMID = step->GetPreStepPoint()->GetTouchableHandle()->GetCopyNumber(1);
+	    fEventAction->AddVectorScin( signalhit, SiPMID ); 
+        }
+    } // end of scintillating fiber
+
+    else if (Lvolume == fCfiber_Core_LV ) { //Cherenkov fiber
 
 	if ( step->GetTrack()->GetParticleDefinition() == G4OpticalPhoton::Definition() ){
-					
+	
 	    G4OpBoundaryProcessStatus theStatus = Undefined;
 
 	    G4ProcessManager* OpManager = G4OpticalPhoton::OpticalPhoton()->GetProcessManager();
@@ -186,31 +190,30 @@ void DRTB23SimSteppingAction::FastSteppingAction( const G4Step* step ) {
 	    }
 
 	    switch ( theStatus ){
-								
+						
 	        case TotalInternalReflection: {
-            G4double distance_to_sipm = fSignalHelper->GetDistanceToSiPM(step);
+                    G4double distance_to_sipm = fSignalHelper->GetDistanceToSiPM(step);
 		    G4int c_signal = fSignalHelper->SmearCSignal( );
-            // Attenuate Signal
-            c_signal = fSignalHelper->AttenuateCSignal(c_signal, distance_to_sipm);								
-		    TowerID = fDetConstruction->GetTowerID(step->GetPreStepPoint()->GetTouchableHandle()->GetCopyNumber(3));		
-	            SiPMTower=fDetConstruction->GetSiPMTower(TowerID);
+                    // Attenuate Signal
+                    c_signal = fSignalHelper->AttenuateCSignal(c_signal, distance_to_sipm);
+		    G4int TowerID = step->GetPreStepPoint()->GetTouchableHandle()->GetCopyNumber(3);		
 		    fEventAction->AddVecCPMT( TowerID, c_signal );
-//		    if ( TowerID != 0 ) { fEventAction->AddVecCPMT( TowerID, c_signal ); }
 
-		    if(SiPMTower > -1){ 
-		        SiPMID = fDetConstruction->GetSiPMID(step->GetPreStepPoint()->GetTouchableHandle()->GetCopyNumber(1));
-			fEventAction->AddVectorCher(SiPMTower*NoFibersTower+SiPMID, c_signal);
+		    if(TowerID == 0){ // in sipm-readout tower
+		        G4int SiPMID = step->GetPreStepPoint()->GetTouchableHandle()->GetCopyNumber(1);
+			fEventAction->AddVectorCher(SiPMID, c_signal);
 	            }
 		    step->GetTrack()->SetTrackStatus( fStopAndKill );
 		}
-		default:
-		    step->GetTrack()->SetTrackStatus( fStopAndKill );
+		default: 
+                    /*step->GetTrack()->SetTrackStatus( fStopAndKill )*/;
 	    } //end of swich cases
-
         } //end of optical photon
-
+        else return;
     } //end of Cherenkov fiber
-   
+
+    else return;
+
 }
 
 //**************************************************

--- a/src/DRTB23SimSteppingAction.cc
+++ b/src/DRTB23SimSteppingAction.cc
@@ -61,15 +61,12 @@ void DRTB23SimSteppingAction::AuxSteppingAction( const G4Step* step ) {
     //--------------------------------------------------
     //Store auxiliary information from event steps
     //--------------------------------------------------
-
-    if ( volume == fDetConstruction->GetLeakCntPV() ){
-        //Take care operator== works with pointers only
-	//if there is a single placement of the volume
-	//use names or cpNo if not the case
-	//
+    
+    // Collect out of world leakage
+    //
+    if (!step->GetTrack()->GetNextVolume()) {
         fEventAction->AddEscapedEnergy(step->GetTrack()->GetKineticEnergy());
-        step->GetTrack()->SetTrackStatus(fStopAndKill);
-    } 
+    }
 
     if ( volume->GetName() == "Clad_S_fiber" ||
          volume->GetName() == "Core_S_fiber" ||
@@ -90,7 +87,6 @@ void DRTB23SimSteppingAction::AuxSteppingAction( const G4Step* step ) {
 
     
     if ( volume != fDetConstruction->GetWorldPV() &&
-         volume != fDetConstruction->GetLeakCntPV() &&
          volume->GetName() != "Preshower_scin" &&
          volume->GetName() != "Preshower_pb" ) { fEventAction->Addenergy(edep); }
    

--- a/src/DRTB23SimSteppingAction.cc
+++ b/src/DRTB23SimSteppingAction.cc
@@ -109,9 +109,6 @@ void DRTB23SimSteppingAction::AuxSteppingAction( const G4Step* step ) {
         fEventAction->AddPSSciEnergy( edep );
     }
     
-    //Collect energy in calo (N.B. not exact method as in 2023 the platform was included)
-    if ( volume != fWorldPV && volume != fPSPV && volume != fPSScinPV ) { fEventAction->Addenergy(edep); }
- 
 }
 
 //Define FastSteppingAction() method


### PR DESCRIPTION
This PR includes a new (better) implementation of the SteppingAction and fixes a few bugs:
- Removed leakage counter that was partially bigger than the world volume, leakage calculated now as out-of-world leakage
- Change preshower volumes implementation with plastic now included in lead -> one volume less implementation, and change preshower vis attributes
- Change fiber volumes implementation with fibers placed inside absorber -> one volume less implementation
- Add getters in DetectorConstruction to access volumes of interest in stepping action
- Use volume pointers in stepping action and access DetectorConstruction via the RunManager
- Add a variable with total number of S and C p.e. in central tower
- Retune light yields after the inclusion of the light attenuation
- Add UI commands in default macro card to avoid listing all physics processes
- Fix bug in calculation of total number of C and S p.e.