### PR TITLE
Adjust world volume dimensions to 2023 tb

### DIFF
--- a/DRTB23Sim_run.mac
+++ b/DRTB23Sim_run.mac
@@ -23,7 +23,7 @@
 /gps/particle e-
 /gps/energy 0.5 GeV
 /gps/direction 0 0 1
-/gps/position 0 0 -55
+/gps/position 0 0 -200 cm
 /gps/pos/type Plane
 /gps/pos/shape Circle
 /gps/pos/radius 0.01 cm

--- a/src/DRTB23SimDetectorConstruction.cc
+++ b/src/DRTB23SimDetectorConstruction.cc
@@ -414,9 +414,9 @@ G4VPhysicalVolume* DRTB23SimDetectorConstruction::DefineVolumes() {
 
     // Geometry parameters of the world, world is a G4Box
     //
-    G4double worldX = 200 * moduleX;
-    G4double worldY = 200 * moduleY;
-    G4double worldZ = 60 * moduleZ;
+    G4double worldX = 100 * moduleX;
+    G4double worldY = 30 * moduleY;
+    G4double worldZ = 5 * moduleZ;
 
     // Geometry parameters of the fiber
     //


### PR DESCRIPTION
Adjust the world volume dimensions to take into account the platform introduced in the 2023 test-beam simulation.